### PR TITLE
fix: use current model for hooks when restoring

### DIFF
--- a/src/resolvers/mutations.ts
+++ b/src/resolvers/mutations.ts
@@ -279,7 +279,7 @@ const restore = async (model: EntityModel, { where }: { where: any }, ctx: FullC
     const data = { prev: relatedEntity, input: {}, normalizedInput, next: { ...relatedEntity, ...normalizedInput } };
     if (ctx.mutationHook) {
       beforeHooks.push(async () => {
-        await ctx.mutationHook(model, 'restore', 'before', data, ctx);
+        await ctx.mutationHook(currentModel, 'restore', 'before', data, ctx);
       });
     }
     mutations.push(async () => {
@@ -288,7 +288,7 @@ const restore = async (model: EntityModel, { where }: { where: any }, ctx: FullC
     });
     if (ctx.mutationHook) {
       afterHooks.push(async () => {
-        await ctx.mutationHook(model, 'restore', 'after', data, ctx);
+        await ctx.mutationHook(currentModel, 'restore', 'after', data, ctx);
       });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated mutation hooks to ensure the correct model context is used during the restore operation. 

No new features or significant changes were introduced in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->