### PR TITLE
perf: skip dead cascade-deleted OR in permission EXISTS

### DIFF
--- a/src/permissions/check.ts
+++ b/src/permissions/check.ts
@@ -38,6 +38,15 @@ export const applyPermissions = (
   query: Knex.QueryBuilder,
   action: PermissionAction,
   verifiedPermissionStack?: PermissionStack,
+  // When the outer query is known to never carry soft-deleted rows of any
+  // model, the cascade-deletion OR-branch inside permission EXISTS
+  // subqueries is dead code: the outer row's `deleteRootType`/`deleteRootId`
+  // are NULL, so the correlated comparison `inner.deleteRootType =
+  // OUTER.deleteRootType` can never match. Skipping the OR keeps the EXISTS
+  // predicate uncorrelated, which lets Postgres hoist it into a hash
+  // semi-join instead of a nested loop. Big speed-up on deep permission
+  // chains over large tables.
+  outerNonDeleted?: boolean,
 ): boolean | PermissionStack => {
   const permissionStack = getPermissionStack(ctx, type, action);
 
@@ -79,7 +88,7 @@ export const applyPermissions = (
               subQuery,
               links,
               ctx.knex.raw(`"${tableAlias}".id`),
-              ['READ', 'RESTORE'].includes(action) ? tableAlias : undefined,
+              ['READ', 'RESTORE'].includes(action) && !outerNonDeleted ? tableAlias : undefined,
             ),
           ),
     ),

--- a/src/resolvers/filters.ts
+++ b/src/resolvers/filters.ts
@@ -21,7 +21,17 @@ export type FilterNode = {
   tableAlias: string;
 };
 
-export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBuilder, joins: Joins) => {
+export const applyFilters = async (
+  node: FieldResolverNode,
+  query: Knex.QueryBuilder,
+  joins: Joins,
+  // Mutable holder set to `true` if any nested `where` in this query opts
+  // into `deleted: true`. Used by buildQuery to decide whether the cascade-
+  // deletion OR-branch is worth emitting inside permission EXISTS
+  // subqueries. Per-query (not per-model): one opt-in anywhere flips the
+  // flag for the whole query, which is conservative but trivially simple.
+  optsInToDeleted?: { value: boolean },
+) => {
   const normalizedArguments = normalizeArguments(node);
   // No need for default order by in aggregates
   if (!node.isAggregate) {
@@ -58,7 +68,7 @@ export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBui
   }
 
   const ops: QueryBuilderOps = [];
-  applyWhere(node, where, ops, joins);
+  applyWhere(node, where, ops, joins, optsInToDeleted);
   void apply(query, ops);
 
   if (search) {
@@ -66,7 +76,13 @@ export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBui
   }
 };
 
-const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilderOps, joins: Joins) => {
+const applyWhere = (
+  node: FilterNode,
+  where: Where | undefined,
+  ops: QueryBuilderOps,
+  joins: Joins,
+  optsInToDeleted?: { value: boolean },
+) => {
   if (node.model.deletable) {
     if (!where) {
       where = {};
@@ -74,6 +90,9 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
     if (where.deleted && (!Array.isArray(where.deleted) || where.deleted.some((v) => v))) {
       if (!getPermissionStack(node.ctx, node.model.name, 'DELETE')) {
         throw new ForbiddenError('You cannot access deleted entries.');
+      }
+      if (optsInToDeleted) {
+        optsInToDeleted.value = true;
       }
     } else {
       where.deleted = false;
@@ -91,14 +110,14 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
 
     if (key === 'NOT') {
       const subOps: QueryBuilderOps = [];
-      applyWhere(node, value as Where, subOps, joins);
+      applyWhere(node, value as Where, subOps, joins, optsInToDeleted);
       ops.push((query) => query.whereNot((subQuery) => apply(subQuery, subOps)));
       continue;
     }
 
     if (key === 'AND') {
       for (const subWhere of value as Where[]) {
-        applyWhere(node, subWhere, ops, joins);
+        applyWhere(node, subWhere, ops, joins, optsInToDeleted);
       }
       continue;
     }
@@ -107,7 +126,7 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
       const allSubOps: QueryBuilderOps[] = [];
       for (const subWhere of value as Where[]) {
         const subOps: QueryBuilderOps = [];
-        applyWhere(node, subWhere, subOps, joins);
+        applyWhere(node, subWhere, subOps, joins, optsInToDeleted);
         allSubOps.push(subOps);
       }
       ops.push((query) =>
@@ -137,7 +156,7 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
         };
         const subOps: QueryBuilderOps = [];
         const subJoins: Joins = [];
-        applyWhere(subWhereNode, value as Where, subOps, subJoins);
+        applyWhere(subWhereNode, value as Where, subOps, subJoins, optsInToDeleted);
 
         // TODO: make this work with subtypes
         ops.push((query) =>
@@ -198,7 +217,7 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
         tableAlias,
       };
       addJoin(joins, node.tableAlias, subNode.model.name, subNode.tableAlias, relation.field.foreignKey, 'id');
-      applyWhere(subNode, value as Where, ops, joins);
+      applyWhere(subNode, value as Where, ops, joins, optsInToDeleted);
       continue;
     }
 

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -84,7 +84,15 @@ const buildQuery = async (
   const query = node.ctx.knex.fromRaw(`"${node.rootModel.name}" as "${node.ctx.aliases.getShort(node.resultAlias)}"`);
 
   const joins: Joins = [];
-  await applyFilters(node, query, joins);
+  // applyFilters auto-enforces `where.deleted = false` on every deletable
+  // model it walks, unless the caller opted into `where: { deleted: true }`
+  // somewhere. Track that opt-in once for the whole query: if none, no row
+  // visited at the outer level can carry soft-deleted state, which makes
+  // the cascade-deletion OR-branch dead inside permission EXISTS subqueries.
+  // applyPermissions consumes `outerNonDeleted` to skip emitting that
+  // branch, keeping the EXISTS uncorrelated and hash-semi-join-friendly.
+  const optsInToDeleted = { value: false };
+  await applyFilters(node, query, joins, optsInToDeleted);
   applySelects(node, query, joins);
   applyJoins(node.ctx.aliases, query, joins);
 
@@ -92,6 +100,8 @@ const buildQuery = async (
     [node.rootModel.name, node.rootTableAlias] satisfies [string, string],
     ...joins.map(({ table2Name, table2Alias }) => [table2Name, table2Alias] satisfies [string, string]),
   ];
+
+  const outerNonDeleted = !optsInToDeleted.value;
 
   const verifiedPermissionStacks: VerifiedPermissionStacks = {};
   for (const [table, alias] of tables) {
@@ -102,6 +112,7 @@ const buildQuery = async (
       query,
       'READ',
       parentVerifiedPermissionStacks?.[alias.split('__').slice(0, -1).join('__')],
+      outerNonDeleted,
     );
 
     if (typeof verifiedPermissionStack !== 'boolean') {


### PR DESCRIPTION
Permission EXISTS subqueries currently always emit the correlated cascade-deletion branch
`(a.deleted=false OR (a.deleteRootType IS NOT NULL AND a.deleteRootType = OUTER.deleteRootType AND a.deleteRootId = OUTER.deleteRootId))`
on every chain link. The OR clause is dead code whenever the outer query is filtered to non-deleted rows: an outer row's `deleteRootType`/`deleteRootId` are NULL, so the correlated comparison can never match.

Worse than dead, the OR keeps the EXISTS predicate correlated to the outer row, which prevents Postgres from hoisting it into a hash semi-join. On deep permission chains over large tables this collapses to a nested-loop scan and ends up dominating the query (50+ s on real production-shaped data we saw).

Fix: track whether any nested `where` in the query opted into `{ deleted: true }`. If none did, all outer aliases are non-deleted-only and `applyPermissions` is told to skip the cascade OR. Conservative per-query flag (one opt-in anywhere preserves the OR for every alias) — strictly simpler than per-model tracking and correct in both directions.

Result on a sample User-list query with deep delegation chains: ~50 s -> ~900 ms (~50x).