### PR TITLE
feat(schema)!: enforce mandatory filters + nonNull-filterable relatio…

### DIFF
--- a/src/schema/generate.ts
+++ b/src/schema/generate.ts
@@ -131,10 +131,36 @@ export const generateDefinitions = ({
             },
           ]),
         ),
-        input(
-          `${model.name}WhereUnique`,
-          model.fields.filter(({ unique }) => unique).map((field) => ({ name: field.name, type: field.type })),
-        ),
+        input(`${model.name}WhereUnique`, [
+          ...model.fields.filter(({ unique }) => unique).map((field) => ({ name: field.name, type: field.type })),
+          // Mandatory filters (filterable: { nonNull: true }) on simple/enum fields — required
+          // on WhereUnique queries too, so callers of `entity(where: { id })` can't bypass the
+          // cascade the plural query enforces.
+          ...model.fields
+            .filter(
+              ({ kind, filterable }) => typeof filterable === 'object' && filterable.nonNull === true && kind !== 'relation',
+            )
+            .map((field) => ({
+              name: field.name,
+              type: field.type,
+              list: true,
+              default: typeof field.filterable === 'object' ? field.filterable.default : undefined,
+              nonNull: true,
+            })),
+          // Same intent for relation FKs marked mandatory-filterable: every singular lookup
+          // must nest the related model's Where, e.g.
+          //   `report(where: { id, relation: { status: [ACTIVE] } })`
+          // Marking a child model's relation FK as `filterable: { nonNull: true }` is what opts
+          // it into this enforcement — the related model's own nested mandatory filters then
+          // apply at the inner Where level.
+          ...model.relations
+            .filter(({ field: { filterable } }) => typeof filterable === 'object' && filterable.nonNull === true)
+            .map(({ name, targetModel }) => ({
+              name,
+              type: `${targetModel.name}Where`,
+              nonNull: true,
+            })),
+        ]),
         ...(model.fields.some(({ orderable }) => orderable)
           ? [
               input(


### PR DESCRIPTION
…ns on WhereUnique

`WhereUnique` historically carried only `unique` fields, so a singular `entity(where: { id })` lookup could bypass the cascade the plural `entities(where: { … })` query enforced through `filterable: { nonNull: true }`. Two practical consequences this commit closes:

1. A model with `filterable: { nonNull: true }` on a simple/enum field (e.g. `Relation.status`) makes `RelationWhere.status` non-nullable — every plural query must opt in — but `RelationWhereUnique` never exposed `status`, so the singular `relation(where: { id })` slipped past the same enforcement.

2. A child model with a relation FK marked `filterable: { nonNull: true }` couldn't nest the related model's Where on a singular lookup — `report(where: { id, relation: { status: [ACTIVE] } })` was a schema error because `ReportWhereUnique` only had `id`.

This commit extends `${model.name}WhereUnique` to include:
- non-relation fields marked `filterable: { nonNull: true }`, typed as `[T]!` with the model's `filterable.default` honored — same shape and nullability as the plural Where, so the cascade is enforced
- relation FK fields marked `filterable: { nonNull: true }`, typed as `RelatedWhere!` — every consumer of the singular query must nest the related model's Where; the related model's own mandatory filters are in turn enforced at the inner Where level

Both additions are non-nullable inputs, so the typegen surfaces every existing `entity(where: { id })` call site that needs to opt into the cascade — the same "surface everything via typegen" pattern that drove the original `filterable: { nonNull: true }` design for plural queries.

Just `filterable: true` relations are NOT exposed here on purpose: the intent is enforcement, and the existing plural Where is where optional filters belong. To enable the cascade for a new relation FK, mark it `filterable: { nonNull: true }` in the model spec — typegen will then fail every site that needs updating.

BREAKING CHANGE: `${model.name}WhereUnique` now carries non-nullable fields when the model has `filterable: { nonNull: true }` simple/enum fields or relation FKs. Any consumer schema with such fields will see its `entity(where: { … })` queries fail typegen until they opt into the cascade by providing those fields. Upgrade requires updating every singular-by-id query to nest the mandatory filters (the typegen errors list exactly the sites that need touching).