### PR TITLE
fix: stop concurrent sub-queries on a shared transaction client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode
 
 # debug
 npm-debug.log*

--- a/src/resolvers/filters.ts
+++ b/src/resolvers/filters.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 import { EntityModel, FullContext, getPermissionStack } from '..';
 import { ForbiddenError, UserInputError } from '../errors';
-import { NormalizedArguments, OrderBy, Where, normalizeArguments } from './arguments';
+import { OrderBy, Where, normalizeArguments } from './arguments';
 import { FieldResolverNode } from './node';
 import { Joins, QueryBuilderOps, addJoin, apply, applyJoins, getColumn, getColumnExpression, ors } from './utils';
 
@@ -21,12 +21,8 @@ export type FilterNode = {
   tableAlias: string;
 };
 
-export const applyFilters = async (
-  node: FieldResolverNode,
-  query: Knex.QueryBuilder,
-  joins: Joins,
-  normalizedArguments: NormalizedArguments = normalizeArguments(node),
-) => {
+export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBuilder, joins: Joins) => {
+  const normalizedArguments = normalizeArguments(node);
   // No need for default order by in aggregates
   if (!node.isAggregate) {
     if (!normalizedArguments.orderBy) {
@@ -68,6 +64,8 @@ export const applyFilters = async (
   if (search) {
     void applySearch(node, search, query);
   }
+
+  return { paginated: normalizedArguments.limit !== undefined || normalizedArguments.offset !== undefined };
 };
 
 const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilderOps, joins: Joins) => {

--- a/src/resolvers/filters.ts
+++ b/src/resolvers/filters.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 import { EntityModel, FullContext, getPermissionStack } from '..';
 import { ForbiddenError, UserInputError } from '../errors';
-import { OrderBy, Where, normalizeArguments } from './arguments';
+import { NormalizedArguments, OrderBy, Where, normalizeArguments } from './arguments';
 import { FieldResolverNode } from './node';
 import { Joins, QueryBuilderOps, addJoin, apply, applyJoins, getColumn, getColumnExpression, ors } from './utils';
 
@@ -21,8 +21,12 @@ export type FilterNode = {
   tableAlias: string;
 };
 
-export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBuilder, joins: Joins) => {
-  const normalizedArguments = normalizeArguments(node);
+export const applyFilters = async (
+  node: FieldResolverNode,
+  query: Knex.QueryBuilder,
+  joins: Joins,
+  normalizedArguments: NormalizedArguments = normalizeArguments(node),
+) => {
   // No need for default order by in aggregates
   if (!node.isAggregate) {
     if (!normalizedArguments.orderBy) {

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -7,7 +7,6 @@ import { NotFoundError } from '../errors';
 import { get, summonByKey } from '../models/utils';
 import { applyPermissions } from '../permissions/check';
 import { PermissionStack } from '../permissions/generate';
-import { normalizeArguments } from './arguments';
 import { applyFilters } from './filters';
 import { FieldResolverNode, ResolverNode, getFragmentSpreads, getInlineFragments, getJoins, getRootFieldNode } from './node';
 import { applySelects } from './selects';
@@ -83,11 +82,8 @@ const buildQuery = async (
   parentVerifiedPermissionStacks?: VerifiedPermissionStacks,
 ): Promise<{ query: Knex.QueryBuilder; verifiedPermissionStacks: VerifiedPermissionStacks; paginated: boolean }> => {
   const query = node.ctx.knex.fromRaw(`"${node.rootModel.name}" as "${node.ctx.aliases.getShort(node.resultAlias)}"`);
-  const normalizedArguments = normalizeArguments(node);
-  const paginated = normalizedArguments.limit !== undefined || normalizedArguments.offset !== undefined;
-
   const joins: Joins = [];
-  await applyFilters(node, query, joins, normalizedArguments);
+  const { paginated } = await applyFilters(node, query, joins);
   applySelects(node, query, joins);
   applyJoins(node.ctx.aliases, query, joins);
 

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -81,11 +81,13 @@ type VerifiedPermissionStacks = Record<string, PermissionStack>;
 const buildQuery = async (
   node: FieldResolverNode,
   parentVerifiedPermissionStacks?: VerifiedPermissionStacks,
-): Promise<{ query: Knex.QueryBuilder; verifiedPermissionStacks: VerifiedPermissionStacks }> => {
+): Promise<{ query: Knex.QueryBuilder; verifiedPermissionStacks: VerifiedPermissionStacks; paginated: boolean }> => {
   const query = node.ctx.knex.fromRaw(`"${node.rootModel.name}" as "${node.ctx.aliases.getShort(node.resultAlias)}"`);
+  const normalizedArguments = normalizeArguments(node);
+  const paginated = normalizedArguments.limit !== undefined || normalizedArguments.offset !== undefined;
 
   const joins: Joins = [];
-  await applyFilters(node, query, joins);
+  await applyFilters(node, query, joins, normalizedArguments);
   applySelects(node, query, joins);
   applyJoins(node.ctx.aliases, query, joins);
 
@@ -110,7 +112,7 @@ const buildQuery = async (
     }
   }
 
-  return { query, verifiedPermissionStacks };
+  return { query, verifiedPermissionStacks, paginated };
 };
 
 const applySubQueries = async (
@@ -141,15 +143,13 @@ const applySubQueries = async (
     const isList = isListType(subNode.fieldDefinition.type);
     entries.forEach((entry) => (entry[fieldName] = isList ? [] : null));
     const foreignKey = subNode.foreignKey;
-    const { query, verifiedPermissionStacks } = await buildQuery(subNode, parentVerifiedPermissionStacks);
+    const { query, verifiedPermissionStacks, paginated } = await buildQuery(subNode, parentVerifiedPermissionStacks);
     const shortTableAlias = subNode.ctx.aliases.getShort(subNode.tableAlias);
     const shortResultAlias = subNode.ctx.aliases.getShort(subNode.resultAlias);
     const foreignKeyColumn = `${shortTableAlias}.${foreignKey}`;
-    const subArgs = normalizeArguments(subNode);
-    const needsPerParentPagination = subArgs.limit !== undefined || subArgs.offset !== undefined;
 
     let rawChildren: Record<string, Knex.Value>[];
-    if (!needsPerParentPagination) {
+    if (!paginated) {
       rawChildren = await query
         .select(`${foreignKeyColumn} as ${shortResultAlias}__${foreignKey}`)
         .whereIn(foreignKeyColumn, ids);

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -7,6 +7,7 @@ import { NotFoundError } from '../errors';
 import { get, summonByKey } from '../models/utils';
 import { applyPermissions } from '../permissions/check';
 import { PermissionStack } from '../permissions/generate';
+import { normalizeArguments } from './arguments';
 import { applyFilters } from './filters';
 import { FieldResolverNode, ResolverNode, getFragmentSpreads, getInlineFragments, getJoins, getRootFieldNode } from './node';
 import { applySelects } from './selects';
@@ -143,16 +144,25 @@ const applySubQueries = async (
     const { query, verifiedPermissionStacks } = await buildQuery(subNode, parentVerifiedPermissionStacks);
     const shortTableAlias = subNode.ctx.aliases.getShort(subNode.tableAlias);
     const shortResultAlias = subNode.ctx.aliases.getShort(subNode.resultAlias);
-    const queries = ids.map((id) =>
-      query
-        .clone()
-        .select(`${shortTableAlias}.${foreignKey} as ${shortResultAlias}__${foreignKey}`)
-        .where({ [`${shortTableAlias}.${foreignKey}`]: id }),
-    );
+    const foreignKeyColumn = `${shortTableAlias}.${foreignKey}`;
+    const subArgs = normalizeArguments(subNode);
+    const needsPerParentPagination = subArgs.limit !== undefined || subArgs.offset !== undefined;
 
-    // TODO: make unionAll faster then promise.all...
-    // const rawChildren = await node.ctx.knex.queryBuilder().unionAll(queries, true);
-    const rawChildren = (await Promise.all(queries)).flat();
+    let rawChildren: Record<string, Knex.Value>[];
+    if (!needsPerParentPagination) {
+      rawChildren = await query
+        .select(`${foreignKeyColumn} as ${shortResultAlias}__${foreignKey}`)
+        .whereIn(foreignKeyColumn, ids);
+    } else {
+      rawChildren = [];
+      for (const id of ids) {
+        const rows = await query
+          .clone()
+          .select(`${foreignKeyColumn} as ${shortResultAlias}__${foreignKey}`)
+          .where({ [foreignKeyColumn]: id });
+        rawChildren.push(...rows);
+      }
+    }
     const children = hydrate(subNode, rawChildren);
 
     for (const child of children) {

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -65,10 +65,7 @@ export type Entry = {
   [field: string]: null | string | number | Entry | Entry[];
 };
 
-export function hydrate<T extends Entry>(
-  node: FieldResolverNode,
-  raw: Record<string, undefined | null | string | Date | number>[],
-): T[] {
+export function hydrate<T extends Entry>(node: FieldResolverNode, raw: Record<string, Knex.Value>[]): T[] {
   const resultAlias = node.resultAlias;
   const res = raw.map((entry) => {
     const res: any = {};


### PR DESCRIPTION
Resolves pg’s “second query queued on the same client” deprecation when GraphQL one-to-many joins run inside a single Knex transaction. Replace Promise.all per parent ID with one whereIn query (or sequential clones when limit/offset needs per-parent pagination), and prepare for pg 9 where this may become a hard error.