### PR TITLE
fix(migrations): enforce PostgreSQL identifier length for constraint …

### DIFF
--- a/src/migrations/generate.ts
+++ b/src/migrations/generate.ts
@@ -873,8 +873,17 @@ export class MigrationGenerator {
     this.writer.writeLine(`table.renameColumn('${from}', '${to}');`);
   }
 
+  private static readonly POSTGRES_MAX_IDENTIFIER_LENGTH = 63;
+
   private getConstraintName(model: EntityModel, entry: { kind: string; name: string }, index: number): string {
-    return `${model.name}_${entry.name}_${entry.kind}_${index}`;
+    const name = `${model.name}_${entry.name}_${entry.kind}_${index}`;
+    if (name.length > MigrationGenerator.POSTGRES_MAX_IDENTIFIER_LENGTH) {
+      throw new Error(
+        `Generated constraint name "${name}" (${name.length} characters) exceeds PostgreSQL's maximum identifier length of ${MigrationGenerator.POSTGRES_MAX_IDENTIFIER_LENGTH} characters. Shorten the constraint name "${entry.name}" on model "${model.name}" (pattern: {table}_{constraintName}_{kind}_{index}).`,
+      );
+    }
+
+    return name;
   }
 
   private static readonly SQL_KEYWORDS = new Set([

--- a/tests/unit/migration-constraints.spec.ts
+++ b/tests/unit/migration-constraints.spec.ts
@@ -346,6 +346,23 @@ describe('MigrationGenerator exclude constraints', () => {
   });
 });
 
+describe('MigrationGenerator constraint name length', () => {
+  it('throws when generated constraint name exceeds PostgreSQL identifier limit', async () => {
+    const models = createProductModels([
+      {
+        kind: 'check',
+        name: 'a'.repeat(50),
+        expression: '"score" >= 0',
+      },
+    ]);
+    const generator = createGenerator([], models);
+
+    await expect(generator.generate()).rejects.toThrow(
+      /Generated constraint name "Product_.*_check_0" \(6\d characters\) exceeds PostgreSQL's maximum identifier length of 63 characters/,
+    );
+  });
+});
+
 describe('MigrationGenerator constraint_trigger validation', () => {
   const triggerModels = new Models([
     {


### PR DESCRIPTION
…names

Added a check in the MigrationGenerator to throw an error if the generated constraint name exceeds PostgreSQL's maximum identifier length of 63 characters. Updated unit tests to verify this behavior.