### PR TITLE
feat!: move deleted filter to top-level query argument

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,10 +10,14 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "angular",
+        "preset": "conventionalcommits",
         "releaseRules": [
           {
             "type": "break",
+            "release": "major"
+          },
+          {
+            "breaking": true,
             "release": "major"
           }
         ]

--- a/docs/docs/10-migration-guides.md
+++ b/docs/docs/10-migration-guides.md
@@ -1,5 +1,32 @@
 # Migration Guides
 
+## Upgrading to the next major version
+
+### `deleted` is a top-level argument, not a `where` filter
+
+The `deleted` field is no longer part of the auto-generated `Where` input. Instead, queries that operate on deletable entities expose a top-level `deleted: Boolean = false` argument. This applies to plural list queries, aggregate queries, singular `entity(where: …)` queries and reverse-relation list fields.
+
+Semantics of the new argument:
+
+- omitted or `deleted: false` (default): only non-deleted entries.
+- `deleted: true`: only deleted entries (requires `DELETE` permission).
+- `deleted: null`: both deleted and non-deleted entries (requires `DELETE` permission).
+
+Update affected queries:
+
+```diff
+- posts(where: { author: { id: "..." }, deleted: [true] }) { id }
++ posts(where: { author: { id: "..." } }, deleted: true) { id }
+
+- invoices_AGGREGATE(where: { deleted: [false] }) { COUNT }
++ invoices_AGGREGATE(deleted: false) { COUNT }
+
+- posts(where: { deleted: [true, false] }) { id }
++ posts(where: {}, deleted: null) { id }
+```
+
+Permission `WHERE` rules can no longer filter on `deleted` via the generated permission `Where` types. The hard-coded `deleted = false` join used by permission chains is unchanged.
+
 ## Upgrading to v19.0.0
 
 ### Configuration changes

--- a/docs/docs/2-models.md
+++ b/docs/docs/2-models.md
@@ -145,7 +145,7 @@ This exposes:
 
 ```graphql
 query {
-  invoices_AGGREGATE(where: { deleted: [false] }) {
+  invoices_AGGREGATE(deleted: false) {
     COUNT
     amount_SUM
   }

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -174,7 +174,6 @@ export class Models {
                 type: 'Boolean',
                 nonNull: true,
                 defaultValue: false,
-                filterable: { default: false },
                 generated: true,
                 ...(typeof entity.deletable === 'object' && entity.deletable.deleted),
               } satisfies BooleanFieldDefinition,

--- a/src/permissions/check.ts
+++ b/src/permissions/check.ts
@@ -38,6 +38,7 @@ export const applyPermissions = (
   query: Knex.QueryBuilder,
   action: PermissionAction,
   verifiedPermissionStack?: PermissionStack,
+  includesDeletedRows?: boolean,
 ): boolean | PermissionStack => {
   const permissionStack = getPermissionStack(ctx, type, action);
 
@@ -79,7 +80,7 @@ export const applyPermissions = (
               subQuery,
               links,
               ctx.knex.raw(`"${tableAlias}".id`),
-              ['READ', 'RESTORE'].includes(action) ? tableAlias : undefined,
+              ['READ', 'RESTORE'].includes(action) && includesDeletedRows ? tableAlias : undefined,
             ),
           ),
     ),

--- a/src/resolvers/arguments.ts
+++ b/src/resolvers/arguments.ts
@@ -25,6 +25,7 @@ export type NormalizedArguments = {
   orderBy?: OrderBy[];
   where?: Where;
   search?: string;
+  deleted?: boolean | null;
   mine?: boolean;
   language?: string;
 };

--- a/src/resolvers/filters.ts
+++ b/src/resolvers/filters.ts
@@ -21,6 +21,9 @@ export type FilterNode = {
   tableAlias: string;
 };
 
+/** True when the query may return soft-deleted rows (`deleted: true` or `deleted: null`). */
+export const includesDeletedRows = (deleted: boolean | null | undefined) => deleted === true || deleted === null;
+
 export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBuilder, joins: Joins) => {
   const normalizedArguments = normalizeArguments(node);
   // No need for default order by in aggregates
@@ -33,7 +36,7 @@ export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBui
       }
     }
   }
-  const { limit, offset, orderBy, where, search } = normalizedArguments;
+  const { limit, offset, orderBy, where, search, deleted } = normalizedArguments;
 
   await node.ctx.queryHook?.({ model: node.model, query, args: normalizedArguments, ctx: node.ctx });
 
@@ -58,6 +61,7 @@ export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBui
   }
 
   const ops: QueryBuilderOps = [];
+  applyDeletedFilter(node, deleted, ops);
   applyWhere(node, where, ops, joins);
   void apply(query, ops);
 
@@ -65,23 +69,36 @@ export const applyFilters = async (node: FieldResolverNode, query: Knex.QueryBui
     void applySearch(node, search, query);
   }
 
-  return { paginated: normalizedArguments.limit !== undefined || normalizedArguments.offset !== undefined };
+  return {
+    paginated: normalizedArguments.limit !== undefined || normalizedArguments.offset !== undefined,
+    includesDeletedRows: includesDeletedRows(deleted),
+  };
+};
+
+const applyDeletedFilter = (node: FilterNode, deleted: boolean | null | undefined, ops: QueryBuilderOps) => {
+  if (!node.model.deletable) {
+    return;
+  }
+  const effective = deleted === undefined ? false : deleted;
+  if (effective !== false && !getPermissionStack(node.ctx, node.model.name, 'DELETE')) {
+    throw new ForbiddenError('You cannot access deleted entries.');
+  }
+  if (effective === null) {
+    return;
+  }
+  const column = getColumn(node, 'deleted');
+  ops.push((query) => query.where({ [column]: effective }));
+};
+
+const applyNestedDeletedDefault = (node: FilterNode, ops: QueryBuilderOps) => {
+  if (!node.model.deletable) {
+    return;
+  }
+  const column = getColumn(node, 'deleted');
+  ops.push((query) => query.where({ [column]: false }));
 };
 
 const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilderOps, joins: Joins) => {
-  if (node.model.deletable) {
-    if (!where) {
-      where = {};
-    }
-    if (where.deleted && (!Array.isArray(where.deleted) || where.deleted.some((v) => v))) {
-      if (!getPermissionStack(node.ctx, node.model.name, 'DELETE')) {
-        throw new ForbiddenError('You cannot access deleted entries.');
-      }
-    } else {
-      where.deleted = false;
-    }
-  }
-
   if (!where) {
     return;
   }
@@ -139,6 +156,7 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
         };
         const subOps: QueryBuilderOps = [];
         const subJoins: Joins = [];
+        applyNestedDeletedDefault(subWhereNode, subOps);
         applyWhere(subWhereNode, value as Where, subOps, subJoins);
 
         // TODO: make this work with subtypes
@@ -200,6 +218,7 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
         tableAlias,
       };
       addJoin(joins, node.tableAlias, subNode.model.name, subNode.tableAlias, relation.field.foreignKey, 'id');
+      applyNestedDeletedDefault(subNode, ops);
       applyWhere(subNode, value as Where, ops, joins);
       continue;
     }

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -83,7 +83,7 @@ const buildQuery = async (
 ): Promise<{ query: Knex.QueryBuilder; verifiedPermissionStacks: VerifiedPermissionStacks; paginated: boolean }> => {
   const query = node.ctx.knex.fromRaw(`"${node.rootModel.name}" as "${node.ctx.aliases.getShort(node.resultAlias)}"`);
   const joins: Joins = [];
-  const { paginated } = await applyFilters(node, query, joins);
+  const { paginated, includesDeletedRows } = await applyFilters(node, query, joins);
   applySelects(node, query, joins);
   applyJoins(node.ctx.aliases, query, joins);
 
@@ -101,6 +101,7 @@ const buildQuery = async (
       query,
       'READ',
       parentVerifiedPermissionStacks?.[alias.split('__').slice(0, -1).join('__')],
+      includesDeletedRows,
     );
 
     if (typeof verifiedPermissionStack !== 'boolean') {

--- a/src/schema/generate.ts
+++ b/src/schema/generate.ts
@@ -42,6 +42,9 @@ const pickWhereVariant = (targetModel: EntityModel, exemptedFieldName?: string):
   };
 };
 
+const deletedArg = (model: EntityModel): Field[] =>
+  model.deletable ? [{ name: 'deleted', type: 'Boolean', defaultValue: false }] : [];
+
 const buildWhereFields = (
   model: EntityModel,
   { isSubWhere = false, exemptedFieldName }: { isSubWhere?: boolean; exemptedFieldName?: string } = {},
@@ -147,6 +150,7 @@ export const generateDefinitions = ({
                     type: variant.typeName,
                     nonNull: variant.nonNull,
                   },
+                  ...deletedArg(targetModel),
                   ...(targetModel.fields.some(({ searchable }) => searchable) ? [{ name: 'search', type: 'String' }] : []),
                   ...(targetModel.fields.some(({ orderable }) => orderable)
                     ? [{ name: 'orderBy', type: `${targetModel.name}OrderBy`, list: true }]
@@ -266,16 +270,17 @@ export const generateDefinitions = ({
       },
       ...entities
         .filter(({ queriable }) => queriable)
-        .map(({ name }) => ({
-          name: typeToField(name),
-          type: name,
+        .map((model) => ({
+          name: typeToField(model.name),
+          type: model.name,
           nonNull: true,
           args: [
             {
               name: 'where',
-              type: `${name}WhereLookup`,
+              type: `${model.name}WhereLookup`,
               nonNull: true,
             },
+            ...deletedArg(model),
           ],
         })),
       ...entities
@@ -291,6 +296,7 @@ export const generateDefinitions = ({
               type: `${model.name}Where`,
               nonNull: hasAnyMandatoryFilterableField(model),
             },
+            ...deletedArg(model),
             ...(model.fields.some(({ searchable }) => searchable) ? [{ name: 'search', type: 'String' }] : []),
             ...(model.fields.some(({ orderable }) => orderable)
               ? [{ name: 'orderBy', type: `${model.name}OrderBy`, list: true }]
@@ -312,6 +318,7 @@ export const generateDefinitions = ({
               type: `${model.name}Where`,
               nonNull: hasAnyMandatoryFilterableField(model),
             },
+            ...deletedArg(model),
             ...(model.fields.some(({ searchable }) => searchable) ? [{ name: 'search', type: 'String' }] : []),
           ],
         })),

--- a/tests/api/delete.spec.ts
+++ b/tests/api/delete.spec.ts
@@ -16,7 +16,7 @@ describe('delete', () => {
       expect(
         await request(gql`
           query GetAnotherObject {
-            anotherObjects(where: { id: "${ANOTHER_ID}", deleted: true }) {
+            anotherObjects(where: { id: "${ANOTHER_ID}" }, deleted: true) {
               id
               deleted
             }

--- a/tests/generated/api/index.ts
+++ b/tests/generated/api/index.ts
@@ -38,6 +38,7 @@ export type AnotherObject = {
 
 
 export type AnotherObjectManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -47,6 +48,7 @@ export type AnotherObjectManyObjectsArgs = {
 
 
 export type AnotherObjectSelfArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -62,7 +64,6 @@ export type AnotherObjectSubWhere = {
   AND?: InputMaybe<Array<AnotherObjectSubWhere>>;
   NOT?: InputMaybe<AnotherObjectSubWhere>;
   OR?: InputMaybe<Array<AnotherObjectSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   manyObjects_NONE?: InputMaybe<SomeObjectWhere>;
   manyObjects_SOME?: InputMaybe<SomeObjectWhere>;
@@ -72,10 +73,13 @@ export type AnotherObjectWhere = {
   AND?: InputMaybe<Array<AnotherObjectSubWhere>>;
   NOT?: InputMaybe<AnotherObjectSubWhere>;
   OR?: InputMaybe<Array<AnotherObjectSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   manyObjects_NONE?: InputMaybe<SomeObjectWhere>;
   manyObjects_SOME?: InputMaybe<SomeObjectWhere>;
+};
+
+export type AnotherObjectWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type AnotherObjectWhereUnique = {
@@ -105,6 +109,7 @@ export type Answer = Reaction & {
 
 
 export type AnswerChildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -113,6 +118,7 @@ export type AnswerChildAnswersArgs = {
 
 
 export type AnswerChildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -121,6 +127,7 @@ export type AnswerChildQuestionsArgs = {
 
 
 export type AnswerChildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -129,6 +136,7 @@ export type AnswerChildReactionsArgs = {
 
 
 export type AnswerChildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -145,7 +153,6 @@ export type AnswerSubWhere = {
   AND?: InputMaybe<Array<AnswerSubWhere>>;
   NOT?: InputMaybe<AnswerSubWhere>;
   OR?: InputMaybe<Array<AnswerSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -153,8 +160,11 @@ export type AnswerWhere = {
   AND?: InputMaybe<Array<AnswerSubWhere>>;
   NOT?: InputMaybe<AnswerSubWhere>;
   OR?: InputMaybe<Array<AnswerSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type AnswerWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type AnswerWhereUnique = {
@@ -336,6 +346,7 @@ export type Query = {
 
 
 export type QueryAnotherObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -344,11 +355,13 @@ export type QueryAnotherObjectsArgs = {
 
 
 export type QueryAnswerArgs = {
-  where: AnswerWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: AnswerWhereLookup;
 };
 
 
 export type QueryAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -357,6 +370,7 @@ export type QueryAnswersArgs = {
 
 
 export type QueryManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -366,11 +380,13 @@ export type QueryManyObjectsArgs = {
 
 
 export type QueryQuestionArgs = {
-  where: QuestionWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: QuestionWhereLookup;
 };
 
 
 export type QueryQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -379,11 +395,13 @@ export type QueryQuestionsArgs = {
 
 
 export type QueryReactionArgs = {
-  where: ReactionWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: ReactionWhereLookup;
 };
 
 
 export type QueryReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -392,11 +410,13 @@ export type QueryReactionsArgs = {
 
 
 export type QueryReviewArgs = {
-  where: ReviewWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: ReviewWhereLookup;
 };
 
 
 export type QueryReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -405,7 +425,8 @@ export type QueryReviewsArgs = {
 
 
 export type QuerySomeObjectArgs = {
-  where: SomeObjectWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: SomeObjectWhereLookup;
 };
 
 export type Question = Reaction & {
@@ -431,6 +452,7 @@ export type Question = Reaction & {
 
 
 export type QuestionChildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -439,6 +461,7 @@ export type QuestionChildAnswersArgs = {
 
 
 export type QuestionChildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -447,6 +470,7 @@ export type QuestionChildQuestionsArgs = {
 
 
 export type QuestionChildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -455,6 +479,7 @@ export type QuestionChildReactionsArgs = {
 
 
 export type QuestionChildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -471,7 +496,6 @@ export type QuestionSubWhere = {
   AND?: InputMaybe<Array<QuestionSubWhere>>;
   NOT?: InputMaybe<QuestionSubWhere>;
   OR?: InputMaybe<Array<QuestionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -479,8 +503,11 @@ export type QuestionWhere = {
   AND?: InputMaybe<Array<QuestionSubWhere>>;
   NOT?: InputMaybe<QuestionSubWhere>;
   OR?: InputMaybe<Array<QuestionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type QuestionWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type QuestionWhereUnique = {
@@ -509,6 +536,7 @@ export type Reaction = {
 
 
 export type ReactionChildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -517,6 +545,7 @@ export type ReactionChildAnswersArgs = {
 
 
 export type ReactionChildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -525,6 +554,7 @@ export type ReactionChildQuestionsArgs = {
 
 
 export type ReactionChildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -533,6 +563,7 @@ export type ReactionChildReactionsArgs = {
 
 
 export type ReactionChildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -549,7 +580,6 @@ export type ReactionSubWhere = {
   AND?: InputMaybe<Array<ReactionSubWhere>>;
   NOT?: InputMaybe<ReactionSubWhere>;
   OR?: InputMaybe<Array<ReactionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -563,8 +593,11 @@ export type ReactionWhere = {
   AND?: InputMaybe<Array<ReactionSubWhere>>;
   NOT?: InputMaybe<ReactionSubWhere>;
   OR?: InputMaybe<Array<ReactionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type ReactionWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type ReactionWhereUnique = {
@@ -595,6 +628,7 @@ export type Review = Reaction & {
 
 
 export type ReviewChildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -603,6 +637,7 @@ export type ReviewChildAnswersArgs = {
 
 
 export type ReviewChildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -611,6 +646,7 @@ export type ReviewChildQuestionsArgs = {
 
 
 export type ReviewChildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -619,6 +655,7 @@ export type ReviewChildReactionsArgs = {
 
 
 export type ReviewChildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -635,7 +672,6 @@ export type ReviewSubWhere = {
   AND?: InputMaybe<Array<ReviewSubWhere>>;
   NOT?: InputMaybe<ReviewSubWhere>;
   OR?: InputMaybe<Array<ReviewSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   rating_GT?: InputMaybe<Scalars['Float']['input']>;
   rating_GTE?: InputMaybe<Scalars['Float']['input']>;
@@ -647,12 +683,15 @@ export type ReviewWhere = {
   AND?: InputMaybe<Array<ReviewSubWhere>>;
   NOT?: InputMaybe<ReviewSubWhere>;
   OR?: InputMaybe<Array<ReviewSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   rating_GT?: InputMaybe<Scalars['Float']['input']>;
   rating_GTE?: InputMaybe<Scalars['Float']['input']>;
   rating_LT?: InputMaybe<Scalars['Float']['input']>;
   rating_LTE?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type ReviewWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type ReviewWhereUnique = {
@@ -707,7 +746,6 @@ export type SomeObjectSubWhere = {
   NOT?: InputMaybe<SomeObjectSubWhere>;
   OR?: InputMaybe<Array<SomeObjectSubWhere>>;
   another?: InputMaybe<AnotherObjectWhere>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   field?: InputMaybe<Array<Scalars['String']['input']>>;
   float?: InputMaybe<Array<Scalars['Float']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
@@ -719,11 +757,14 @@ export type SomeObjectWhere = {
   NOT?: InputMaybe<SomeObjectSubWhere>;
   OR?: InputMaybe<Array<SomeObjectSubWhere>>;
   another?: InputMaybe<AnotherObjectWhere>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   field?: InputMaybe<Array<Scalars['String']['input']>>;
   float?: InputMaybe<Array<Scalars['Float']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   xyz?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type SomeObjectWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type SomeObjectWhereUnique = {
@@ -779,6 +820,7 @@ export type User = {
 
 
 export type UserCreatedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -787,6 +829,7 @@ export type UserCreatedAnswersArgs = {
 
 
 export type UserCreatedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -796,6 +839,7 @@ export type UserCreatedManyObjectsArgs = {
 
 
 export type UserCreatedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -804,6 +848,7 @@ export type UserCreatedQuestionsArgs = {
 
 
 export type UserCreatedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -812,6 +857,7 @@ export type UserCreatedReactionsArgs = {
 
 
 export type UserCreatedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -820,6 +866,7 @@ export type UserCreatedReviewsArgs = {
 
 
 export type UserDeletedAnotherObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -828,6 +875,7 @@ export type UserDeletedAnotherObjectsArgs = {
 
 
 export type UserDeletedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -836,6 +884,7 @@ export type UserDeletedAnswersArgs = {
 
 
 export type UserDeletedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -845,6 +894,7 @@ export type UserDeletedManyObjectsArgs = {
 
 
 export type UserDeletedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -853,6 +903,7 @@ export type UserDeletedQuestionsArgs = {
 
 
 export type UserDeletedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -861,6 +912,7 @@ export type UserDeletedReactionsArgs = {
 
 
 export type UserDeletedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -869,6 +921,7 @@ export type UserDeletedReviewsArgs = {
 
 
 export type UserUpdatedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -877,6 +930,7 @@ export type UserUpdatedAnswersArgs = {
 
 
 export type UserUpdatedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -886,6 +940,7 @@ export type UserUpdatedManyObjectsArgs = {
 
 
 export type UserUpdatedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -894,6 +949,7 @@ export type UserUpdatedQuestionsArgs = {
 
 
 export type UserUpdatedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -902,6 +958,7 @@ export type UserUpdatedReactionsArgs = {
 
 
 export type UserUpdatedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -920,6 +977,10 @@ export type UserWhere = {
   NOT?: InputMaybe<UserSubWhere>;
   OR?: InputMaybe<Array<UserSubWhere>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type UserWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type UserWhereUnique = {
@@ -1018,11 +1079,13 @@ export type ResolversTypes = {
   AnotherObjectOrderBy: AnotherObjectOrderBy;
   AnotherObjectSubWhere: AnotherObjectSubWhere;
   AnotherObjectWhere: AnotherObjectWhere;
+  AnotherObjectWhereLookup: AnotherObjectWhereLookup;
   AnotherObjectWhereUnique: AnotherObjectWhereUnique;
   Answer: ResolverTypeWrapper<Omit<Answer, 'childAnswers' | 'childQuestions' | 'childReactions' | 'childReviews' | 'createdBy' | 'deletedBy' | 'parent' | 'updatedBy'> & { childAnswers: Array<ResolversTypes['Answer']>, childQuestions: Array<ResolversTypes['Question']>, childReactions: Array<ResolversTypes['Reaction']>, childReviews: Array<ResolversTypes['Review']>, createdBy: ResolversTypes['User'], deletedBy?: Maybe<ResolversTypes['User']>, parent?: Maybe<ResolversTypes['Reaction']>, updatedBy: ResolversTypes['User'] }>;
   AnswerOrderBy: AnswerOrderBy;
   AnswerSubWhere: AnswerSubWhere;
   AnswerWhere: AnswerWhere;
+  AnswerWhereLookup: AnswerWhereLookup;
   AnswerWhereUnique: AnswerWhereUnique;
   Bird: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['Bird']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
@@ -1043,17 +1106,20 @@ export type ResolversTypes = {
   QuestionOrderBy: QuestionOrderBy;
   QuestionSubWhere: QuestionSubWhere;
   QuestionWhere: QuestionWhere;
+  QuestionWhereLookup: QuestionWhereLookup;
   QuestionWhereUnique: QuestionWhereUnique;
   Reaction: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Reaction']>;
   ReactionOrderBy: ReactionOrderBy;
   ReactionSubWhere: ReactionSubWhere;
   ReactionType: ReactionType;
   ReactionWhere: ReactionWhere;
+  ReactionWhereLookup: ReactionWhereLookup;
   ReactionWhereUnique: ReactionWhereUnique;
   Review: ResolverTypeWrapper<Omit<Review, 'childAnswers' | 'childQuestions' | 'childReactions' | 'childReviews' | 'createdBy' | 'deletedBy' | 'parent' | 'updatedBy'> & { childAnswers: Array<ResolversTypes['Answer']>, childQuestions: Array<ResolversTypes['Question']>, childReactions: Array<ResolversTypes['Reaction']>, childReviews: Array<ResolversTypes['Review']>, createdBy: ResolversTypes['User'], deletedBy?: Maybe<ResolversTypes['User']>, parent?: Maybe<ResolversTypes['Reaction']>, updatedBy: ResolversTypes['User'] }>;
   ReviewOrderBy: ReviewOrderBy;
   ReviewSubWhere: ReviewSubWhere;
   ReviewWhere: ReviewWhere;
+  ReviewWhereLookup: ReviewWhereLookup;
   ReviewWhereUnique: ReviewWhereUnique;
   Role: Role;
   SomeEnum: SomeEnum;
@@ -1061,6 +1127,7 @@ export type ResolversTypes = {
   SomeObjectOrderBy: SomeObjectOrderBy;
   SomeObjectSubWhere: SomeObjectSubWhere;
   SomeObjectWhere: SomeObjectWhere;
+  SomeObjectWhereLookup: SomeObjectWhereLookup;
   SomeObjectWhereUnique: SomeObjectWhereUnique;
   SomeRawObject: ResolverTypeWrapper<SomeRawObject>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
@@ -1073,6 +1140,7 @@ export type ResolversTypes = {
   User: ResolverTypeWrapper<Omit<User, 'createdAnswers' | 'createdManyObjects' | 'createdQuestions' | 'createdReactions' | 'createdReviews' | 'deletedAnotherObjects' | 'deletedAnswers' | 'deletedManyObjects' | 'deletedQuestions' | 'deletedReactions' | 'deletedReviews' | 'updatedAnswers' | 'updatedManyObjects' | 'updatedQuestions' | 'updatedReactions' | 'updatedReviews'> & { createdAnswers: Array<ResolversTypes['Answer']>, createdManyObjects: Array<ResolversTypes['SomeObject']>, createdQuestions: Array<ResolversTypes['Question']>, createdReactions: Array<ResolversTypes['Reaction']>, createdReviews: Array<ResolversTypes['Review']>, deletedAnotherObjects: Array<ResolversTypes['AnotherObject']>, deletedAnswers: Array<ResolversTypes['Answer']>, deletedManyObjects: Array<ResolversTypes['SomeObject']>, deletedQuestions: Array<ResolversTypes['Question']>, deletedReactions: Array<ResolversTypes['Reaction']>, deletedReviews: Array<ResolversTypes['Review']>, updatedAnswers: Array<ResolversTypes['Answer']>, updatedManyObjects: Array<ResolversTypes['SomeObject']>, updatedQuestions: Array<ResolversTypes['Question']>, updatedReactions: Array<ResolversTypes['Reaction']>, updatedReviews: Array<ResolversTypes['Review']> }>;
   UserSubWhere: UserSubWhere;
   UserWhere: UserWhere;
+  UserWhereLookup: UserWhereLookup;
   UserWhereUnique: UserWhereUnique;
 };
 
@@ -1082,11 +1150,13 @@ export type ResolversParentTypes = {
   AnotherObjectOrderBy: AnotherObjectOrderBy;
   AnotherObjectSubWhere: AnotherObjectSubWhere;
   AnotherObjectWhere: AnotherObjectWhere;
+  AnotherObjectWhereLookup: AnotherObjectWhereLookup;
   AnotherObjectWhereUnique: AnotherObjectWhereUnique;
   Answer: Omit<Answer, 'childAnswers' | 'childQuestions' | 'childReactions' | 'childReviews' | 'createdBy' | 'deletedBy' | 'parent' | 'updatedBy'> & { childAnswers: Array<ResolversParentTypes['Answer']>, childQuestions: Array<ResolversParentTypes['Question']>, childReactions: Array<ResolversParentTypes['Reaction']>, childReviews: Array<ResolversParentTypes['Review']>, createdBy: ResolversParentTypes['User'], deletedBy?: Maybe<ResolversParentTypes['User']>, parent?: Maybe<ResolversParentTypes['Reaction']>, updatedBy: ResolversParentTypes['User'] };
   AnswerOrderBy: AnswerOrderBy;
   AnswerSubWhere: AnswerSubWhere;
   AnswerWhere: AnswerWhere;
+  AnswerWhereLookup: AnswerWhereLookup;
   AnswerWhereUnique: AnswerWhereUnique;
   Bird: ResolversUnionTypes<ResolversParentTypes>['Bird'];
   Boolean: Scalars['Boolean']['output'];
@@ -1106,21 +1176,25 @@ export type ResolversParentTypes = {
   QuestionOrderBy: QuestionOrderBy;
   QuestionSubWhere: QuestionSubWhere;
   QuestionWhere: QuestionWhere;
+  QuestionWhereLookup: QuestionWhereLookup;
   QuestionWhereUnique: QuestionWhereUnique;
   Reaction: ResolversInterfaceTypes<ResolversParentTypes>['Reaction'];
   ReactionOrderBy: ReactionOrderBy;
   ReactionSubWhere: ReactionSubWhere;
   ReactionWhere: ReactionWhere;
+  ReactionWhereLookup: ReactionWhereLookup;
   ReactionWhereUnique: ReactionWhereUnique;
   Review: Omit<Review, 'childAnswers' | 'childQuestions' | 'childReactions' | 'childReviews' | 'createdBy' | 'deletedBy' | 'parent' | 'updatedBy'> & { childAnswers: Array<ResolversParentTypes['Answer']>, childQuestions: Array<ResolversParentTypes['Question']>, childReactions: Array<ResolversParentTypes['Reaction']>, childReviews: Array<ResolversParentTypes['Review']>, createdBy: ResolversParentTypes['User'], deletedBy?: Maybe<ResolversParentTypes['User']>, parent?: Maybe<ResolversParentTypes['Reaction']>, updatedBy: ResolversParentTypes['User'] };
   ReviewOrderBy: ReviewOrderBy;
   ReviewSubWhere: ReviewSubWhere;
   ReviewWhere: ReviewWhere;
+  ReviewWhereLookup: ReviewWhereLookup;
   ReviewWhereUnique: ReviewWhereUnique;
   SomeObject: Omit<SomeObject, 'another' | 'createdBy' | 'deletedBy' | 'updatedBy'> & { another?: Maybe<ResolversParentTypes['AnotherObject']>, createdBy: ResolversParentTypes['User'], deletedBy?: Maybe<ResolversParentTypes['User']>, updatedBy: ResolversParentTypes['User'] };
   SomeObjectOrderBy: SomeObjectOrderBy;
   SomeObjectSubWhere: SomeObjectSubWhere;
   SomeObjectWhere: SomeObjectWhere;
+  SomeObjectWhereLookup: SomeObjectWhereLookup;
   SomeObjectWhereUnique: SomeObjectWhereUnique;
   SomeRawObject: SomeRawObject;
   String: Scalars['String']['output'];
@@ -1133,6 +1207,7 @@ export type ResolversParentTypes = {
   User: Omit<User, 'createdAnswers' | 'createdManyObjects' | 'createdQuestions' | 'createdReactions' | 'createdReviews' | 'deletedAnotherObjects' | 'deletedAnswers' | 'deletedManyObjects' | 'deletedQuestions' | 'deletedReactions' | 'deletedReviews' | 'updatedAnswers' | 'updatedManyObjects' | 'updatedQuestions' | 'updatedReactions' | 'updatedReviews'> & { createdAnswers: Array<ResolversParentTypes['Answer']>, createdManyObjects: Array<ResolversParentTypes['SomeObject']>, createdQuestions: Array<ResolversParentTypes['Question']>, createdReactions: Array<ResolversParentTypes['Reaction']>, createdReviews: Array<ResolversParentTypes['Review']>, deletedAnotherObjects: Array<ResolversParentTypes['AnotherObject']>, deletedAnswers: Array<ResolversParentTypes['Answer']>, deletedManyObjects: Array<ResolversParentTypes['SomeObject']>, deletedQuestions: Array<ResolversParentTypes['Question']>, deletedReactions: Array<ResolversParentTypes['Reaction']>, deletedReviews: Array<ResolversParentTypes['Review']>, updatedAnswers: Array<ResolversParentTypes['Answer']>, updatedManyObjects: Array<ResolversParentTypes['SomeObject']>, updatedQuestions: Array<ResolversParentTypes['Question']>, updatedReactions: Array<ResolversParentTypes['Reaction']>, updatedReviews: Array<ResolversParentTypes['Review']> };
   UserSubWhere: UserSubWhere;
   UserWhere: UserWhere;
+  UserWhereLookup: UserWhereLookup;
   UserWhereUnique: UserWhereUnique;
 };
 
@@ -1143,17 +1218,17 @@ export type AnotherObjectResolvers<ContextType = any, ParentType extends Resolve
   deletedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   deletedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  manyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, Partial<AnotherObjectManyObjectsArgs>>;
+  manyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, RequireFields<AnotherObjectManyObjectsArgs, 'deleted'>>;
   myself?: Resolver<Maybe<ResolversTypes['AnotherObject']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  self?: Resolver<Maybe<ResolversTypes['AnotherObject']>, ParentType, ContextType, Partial<AnotherObjectSelfArgs>>;
+  self?: Resolver<Maybe<ResolversTypes['AnotherObject']>, ParentType, ContextType, RequireFields<AnotherObjectSelfArgs, 'deleted'>>;
 };
 
 export type AnswerResolvers<ContextType = any, ParentType extends ResolversParentTypes['Answer'] = ResolversParentTypes['Answer']> = {
-  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<AnswerChildAnswersArgs>>;
-  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<AnswerChildQuestionsArgs>>;
-  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<AnswerChildReactionsArgs>>;
-  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<AnswerChildReviewsArgs>>;
+  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<AnswerChildAnswersArgs, 'deleted'>>;
+  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<AnswerChildQuestionsArgs, 'deleted'>>;
+  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<AnswerChildReactionsArgs, 'deleted'>>;
+  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<AnswerChildReviewsArgs, 'deleted'>>;
   content?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   createdBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
@@ -1210,26 +1285,26 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  anotherObjects?: Resolver<Array<ResolversTypes['AnotherObject']>, ParentType, ContextType, Partial<QueryAnotherObjectsArgs>>;
-  answer?: Resolver<ResolversTypes['Answer'], ParentType, ContextType, RequireFields<QueryAnswerArgs, 'where'>>;
-  answers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<QueryAnswersArgs>>;
+  anotherObjects?: Resolver<Array<ResolversTypes['AnotherObject']>, ParentType, ContextType, RequireFields<QueryAnotherObjectsArgs, 'deleted'>>;
+  answer?: Resolver<ResolversTypes['Answer'], ParentType, ContextType, RequireFields<QueryAnswerArgs, 'deleted' | 'where'>>;
+  answers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'deleted'>>;
   birds?: Resolver<Array<ResolversTypes['Bird']>, ParentType, ContextType>;
-  manyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, Partial<QueryManyObjectsArgs>>;
+  manyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, RequireFields<QueryManyObjectsArgs, 'deleted'>>;
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  question?: Resolver<ResolversTypes['Question'], ParentType, ContextType, RequireFields<QueryQuestionArgs, 'where'>>;
-  questions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<QueryQuestionsArgs>>;
-  reaction?: Resolver<ResolversTypes['Reaction'], ParentType, ContextType, RequireFields<QueryReactionArgs, 'where'>>;
-  reactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<QueryReactionsArgs>>;
-  review?: Resolver<ResolversTypes['Review'], ParentType, ContextType, RequireFields<QueryReviewArgs, 'where'>>;
-  reviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<QueryReviewsArgs>>;
-  someObject?: Resolver<ResolversTypes['SomeObject'], ParentType, ContextType, RequireFields<QuerySomeObjectArgs, 'where'>>;
+  question?: Resolver<ResolversTypes['Question'], ParentType, ContextType, RequireFields<QueryQuestionArgs, 'deleted' | 'where'>>;
+  questions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionsArgs, 'deleted'>>;
+  reaction?: Resolver<ResolversTypes['Reaction'], ParentType, ContextType, RequireFields<QueryReactionArgs, 'deleted' | 'where'>>;
+  reactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<QueryReactionsArgs, 'deleted'>>;
+  review?: Resolver<ResolversTypes['Review'], ParentType, ContextType, RequireFields<QueryReviewArgs, 'deleted' | 'where'>>;
+  reviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<QueryReviewsArgs, 'deleted'>>;
+  someObject?: Resolver<ResolversTypes['SomeObject'], ParentType, ContextType, RequireFields<QuerySomeObjectArgs, 'deleted' | 'where'>>;
 };
 
 export type QuestionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Question'] = ResolversParentTypes['Question']> = {
-  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<QuestionChildAnswersArgs>>;
-  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<QuestionChildQuestionsArgs>>;
-  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<QuestionChildReactionsArgs>>;
-  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<QuestionChildReviewsArgs>>;
+  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QuestionChildAnswersArgs, 'deleted'>>;
+  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QuestionChildQuestionsArgs, 'deleted'>>;
+  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<QuestionChildReactionsArgs, 'deleted'>>;
+  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<QuestionChildReviewsArgs, 'deleted'>>;
   content?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   createdBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
@@ -1251,10 +1326,10 @@ export type ReactionResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type ReviewResolvers<ContextType = any, ParentType extends ResolversParentTypes['Review'] = ResolversParentTypes['Review']> = {
-  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<ReviewChildAnswersArgs>>;
-  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<ReviewChildQuestionsArgs>>;
-  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<ReviewChildReactionsArgs>>;
-  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<ReviewChildReviewsArgs>>;
+  childAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<ReviewChildAnswersArgs, 'deleted'>>;
+  childQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<ReviewChildQuestionsArgs, 'deleted'>>;
+  childReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<ReviewChildReactionsArgs, 'deleted'>>;
+  childReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<ReviewChildReviewsArgs, 'deleted'>>;
   content?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   createdBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
@@ -1304,24 +1379,24 @@ export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-  createdAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<UserCreatedAnswersArgs>>;
-  createdManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, Partial<UserCreatedManyObjectsArgs>>;
-  createdQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<UserCreatedQuestionsArgs>>;
-  createdReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<UserCreatedReactionsArgs>>;
-  createdReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<UserCreatedReviewsArgs>>;
-  deletedAnotherObjects?: Resolver<Array<ResolversTypes['AnotherObject']>, ParentType, ContextType, Partial<UserDeletedAnotherObjectsArgs>>;
-  deletedAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<UserDeletedAnswersArgs>>;
-  deletedManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, Partial<UserDeletedManyObjectsArgs>>;
-  deletedQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<UserDeletedQuestionsArgs>>;
-  deletedReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<UserDeletedReactionsArgs>>;
-  deletedReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<UserDeletedReviewsArgs>>;
+  createdAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<UserCreatedAnswersArgs, 'deleted'>>;
+  createdManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, RequireFields<UserCreatedManyObjectsArgs, 'deleted'>>;
+  createdQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<UserCreatedQuestionsArgs, 'deleted'>>;
+  createdReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<UserCreatedReactionsArgs, 'deleted'>>;
+  createdReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<UserCreatedReviewsArgs, 'deleted'>>;
+  deletedAnotherObjects?: Resolver<Array<ResolversTypes['AnotherObject']>, ParentType, ContextType, RequireFields<UserDeletedAnotherObjectsArgs, 'deleted'>>;
+  deletedAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<UserDeletedAnswersArgs, 'deleted'>>;
+  deletedManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, RequireFields<UserDeletedManyObjectsArgs, 'deleted'>>;
+  deletedQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<UserDeletedQuestionsArgs, 'deleted'>>;
+  deletedReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<UserDeletedReactionsArgs, 'deleted'>>;
+  deletedReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<UserDeletedReviewsArgs, 'deleted'>>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   role?: Resolver<ResolversTypes['Role'], ParentType, ContextType>;
-  updatedAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, Partial<UserUpdatedAnswersArgs>>;
-  updatedManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, Partial<UserUpdatedManyObjectsArgs>>;
-  updatedQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, Partial<UserUpdatedQuestionsArgs>>;
-  updatedReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, Partial<UserUpdatedReactionsArgs>>;
-  updatedReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, Partial<UserUpdatedReviewsArgs>>;
+  updatedAnswers?: Resolver<Array<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<UserUpdatedAnswersArgs, 'deleted'>>;
+  updatedManyObjects?: Resolver<Array<ResolversTypes['SomeObject']>, ParentType, ContextType, RequireFields<UserUpdatedManyObjectsArgs, 'deleted'>>;
+  updatedQuestions?: Resolver<Array<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<UserUpdatedQuestionsArgs, 'deleted'>>;
+  updatedReactions?: Resolver<Array<ResolversTypes['Reaction']>, ParentType, ContextType, RequireFields<UserUpdatedReactionsArgs, 'deleted'>>;
+  updatedReviews?: Resolver<Array<ResolversTypes['Review']>, ParentType, ContextType, RequireFields<UserUpdatedReviewsArgs, 'deleted'>>;
   username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 

--- a/tests/generated/client/index.ts
+++ b/tests/generated/client/index.ts
@@ -33,6 +33,7 @@ export type AnotherObject = {
 
 
 export type AnotherObjectmanyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -42,6 +43,7 @@ export type AnotherObjectmanyObjectsArgs = {
 
 
 export type AnotherObjectselfArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -57,7 +59,6 @@ export type AnotherObjectSubWhere = {
   AND?: InputMaybe<Array<AnotherObjectSubWhere>>;
   NOT?: InputMaybe<AnotherObjectSubWhere>;
   OR?: InputMaybe<Array<AnotherObjectSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   manyObjects_NONE?: InputMaybe<SomeObjectWhere>;
   manyObjects_SOME?: InputMaybe<SomeObjectWhere>;
@@ -67,10 +68,13 @@ export type AnotherObjectWhere = {
   AND?: InputMaybe<Array<AnotherObjectSubWhere>>;
   NOT?: InputMaybe<AnotherObjectSubWhere>;
   OR?: InputMaybe<Array<AnotherObjectSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   manyObjects_NONE?: InputMaybe<SomeObjectWhere>;
   manyObjects_SOME?: InputMaybe<SomeObjectWhere>;
+};
+
+export type AnotherObjectWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type AnotherObjectWhereUnique = {
@@ -99,6 +103,7 @@ export type Answer = Reaction & {
 
 
 export type AnswerchildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -107,6 +112,7 @@ export type AnswerchildAnswersArgs = {
 
 
 export type AnswerchildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -115,6 +121,7 @@ export type AnswerchildQuestionsArgs = {
 
 
 export type AnswerchildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -123,6 +130,7 @@ export type AnswerchildReactionsArgs = {
 
 
 export type AnswerchildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -139,7 +147,6 @@ export type AnswerSubWhere = {
   AND?: InputMaybe<Array<AnswerSubWhere>>;
   NOT?: InputMaybe<AnswerSubWhere>;
   OR?: InputMaybe<Array<AnswerSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -147,8 +154,11 @@ export type AnswerWhere = {
   AND?: InputMaybe<Array<AnswerSubWhere>>;
   NOT?: InputMaybe<AnswerSubWhere>;
   OR?: InputMaybe<Array<AnswerSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type AnswerWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type AnswerWhereUnique = {
@@ -326,6 +336,7 @@ export type Query = {
 
 
 export type QueryanotherObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -334,11 +345,13 @@ export type QueryanotherObjectsArgs = {
 
 
 export type QueryanswerArgs = {
-  where: AnswerWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: AnswerWhereLookup;
 };
 
 
 export type QueryanswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -347,6 +360,7 @@ export type QueryanswersArgs = {
 
 
 export type QuerymanyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -356,11 +370,13 @@ export type QuerymanyObjectsArgs = {
 
 
 export type QueryquestionArgs = {
-  where: QuestionWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: QuestionWhereLookup;
 };
 
 
 export type QueryquestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -369,11 +385,13 @@ export type QueryquestionsArgs = {
 
 
 export type QueryreactionArgs = {
-  where: ReactionWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: ReactionWhereLookup;
 };
 
 
 export type QueryreactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -382,11 +400,13 @@ export type QueryreactionsArgs = {
 
 
 export type QueryreviewArgs = {
-  where: ReviewWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: ReviewWhereLookup;
 };
 
 
 export type QueryreviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -395,7 +415,8 @@ export type QueryreviewsArgs = {
 
 
 export type QuerysomeObjectArgs = {
-  where: SomeObjectWhereUnique;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  where: SomeObjectWhereLookup;
 };
 
 export type Question = Reaction & {
@@ -420,6 +441,7 @@ export type Question = Reaction & {
 
 
 export type QuestionchildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -428,6 +450,7 @@ export type QuestionchildAnswersArgs = {
 
 
 export type QuestionchildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -436,6 +459,7 @@ export type QuestionchildQuestionsArgs = {
 
 
 export type QuestionchildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -444,6 +468,7 @@ export type QuestionchildReactionsArgs = {
 
 
 export type QuestionchildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -460,7 +485,6 @@ export type QuestionSubWhere = {
   AND?: InputMaybe<Array<QuestionSubWhere>>;
   NOT?: InputMaybe<QuestionSubWhere>;
   OR?: InputMaybe<Array<QuestionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -468,8 +492,11 @@ export type QuestionWhere = {
   AND?: InputMaybe<Array<QuestionSubWhere>>;
   NOT?: InputMaybe<QuestionSubWhere>;
   OR?: InputMaybe<Array<QuestionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type QuestionWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type QuestionWhereUnique = {
@@ -498,6 +525,7 @@ export type Reaction = {
 
 
 export type ReactionchildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -506,6 +534,7 @@ export type ReactionchildAnswersArgs = {
 
 
 export type ReactionchildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -514,6 +543,7 @@ export type ReactionchildQuestionsArgs = {
 
 
 export type ReactionchildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -522,6 +552,7 @@ export type ReactionchildReactionsArgs = {
 
 
 export type ReactionchildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -538,7 +569,6 @@ export type ReactionSubWhere = {
   AND?: InputMaybe<Array<ReactionSubWhere>>;
   NOT?: InputMaybe<ReactionSubWhere>;
   OR?: InputMaybe<Array<ReactionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
@@ -552,8 +582,11 @@ export type ReactionWhere = {
   AND?: InputMaybe<Array<ReactionSubWhere>>;
   NOT?: InputMaybe<ReactionSubWhere>;
   OR?: InputMaybe<Array<ReactionSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type ReactionWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type ReactionWhereUnique = {
@@ -583,6 +616,7 @@ export type Review = Reaction & {
 
 
 export type ReviewchildAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -591,6 +625,7 @@ export type ReviewchildAnswersArgs = {
 
 
 export type ReviewchildQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -599,6 +634,7 @@ export type ReviewchildQuestionsArgs = {
 
 
 export type ReviewchildReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -607,6 +643,7 @@ export type ReviewchildReactionsArgs = {
 
 
 export type ReviewchildReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -623,7 +660,6 @@ export type ReviewSubWhere = {
   AND?: InputMaybe<Array<ReviewSubWhere>>;
   NOT?: InputMaybe<ReviewSubWhere>;
   OR?: InputMaybe<Array<ReviewSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   rating_GT?: InputMaybe<Scalars['Float']['input']>;
   rating_GTE?: InputMaybe<Scalars['Float']['input']>;
@@ -635,12 +671,15 @@ export type ReviewWhere = {
   AND?: InputMaybe<Array<ReviewSubWhere>>;
   NOT?: InputMaybe<ReviewSubWhere>;
   OR?: InputMaybe<Array<ReviewSubWhere>>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   rating_GT?: InputMaybe<Scalars['Float']['input']>;
   rating_GTE?: InputMaybe<Scalars['Float']['input']>;
   rating_LT?: InputMaybe<Scalars['Float']['input']>;
   rating_LTE?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type ReviewWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type ReviewWhereUnique = {
@@ -694,7 +733,6 @@ export type SomeObjectSubWhere = {
   NOT?: InputMaybe<SomeObjectSubWhere>;
   OR?: InputMaybe<Array<SomeObjectSubWhere>>;
   another?: InputMaybe<AnotherObjectWhere>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   field?: InputMaybe<Array<Scalars['String']['input']>>;
   float?: InputMaybe<Array<Scalars['Float']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
@@ -706,11 +744,14 @@ export type SomeObjectWhere = {
   NOT?: InputMaybe<SomeObjectSubWhere>;
   OR?: InputMaybe<Array<SomeObjectSubWhere>>;
   another?: InputMaybe<AnotherObjectWhere>;
-  deleted?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   field?: InputMaybe<Array<Scalars['String']['input']>>;
   float?: InputMaybe<Array<Scalars['Float']['input']>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
   xyz?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type SomeObjectWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type SomeObjectWhereUnique = {
@@ -764,6 +805,7 @@ export type User = {
 
 
 export type UsercreatedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -772,6 +814,7 @@ export type UsercreatedAnswersArgs = {
 
 
 export type UsercreatedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -781,6 +824,7 @@ export type UsercreatedManyObjectsArgs = {
 
 
 export type UsercreatedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -789,6 +833,7 @@ export type UsercreatedQuestionsArgs = {
 
 
 export type UsercreatedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -797,6 +842,7 @@ export type UsercreatedReactionsArgs = {
 
 
 export type UsercreatedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -805,6 +851,7 @@ export type UsercreatedReviewsArgs = {
 
 
 export type UserdeletedAnotherObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnotherObjectOrderBy>>;
@@ -813,6 +860,7 @@ export type UserdeletedAnotherObjectsArgs = {
 
 
 export type UserdeletedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -821,6 +869,7 @@ export type UserdeletedAnswersArgs = {
 
 
 export type UserdeletedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -830,6 +879,7 @@ export type UserdeletedManyObjectsArgs = {
 
 
 export type UserdeletedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -838,6 +888,7 @@ export type UserdeletedQuestionsArgs = {
 
 
 export type UserdeletedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -846,6 +897,7 @@ export type UserdeletedReactionsArgs = {
 
 
 export type UserdeletedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -854,6 +906,7 @@ export type UserdeletedReviewsArgs = {
 
 
 export type UserupdatedAnswersArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AnswerOrderBy>>;
@@ -862,6 +915,7 @@ export type UserupdatedAnswersArgs = {
 
 
 export type UserupdatedManyObjectsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<SomeObjectOrderBy>>;
@@ -871,6 +925,7 @@ export type UserupdatedManyObjectsArgs = {
 
 
 export type UserupdatedQuestionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<QuestionOrderBy>>;
@@ -879,6 +934,7 @@ export type UserupdatedQuestionsArgs = {
 
 
 export type UserupdatedReactionsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReactionOrderBy>>;
@@ -887,6 +943,7 @@ export type UserupdatedReactionsArgs = {
 
 
 export type UserupdatedReviewsArgs = {
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ReviewOrderBy>>;
@@ -905,6 +962,10 @@ export type UserWhere = {
   NOT?: InputMaybe<UserSubWhere>;
   OR?: InputMaybe<Array<UserSubWhere>>;
   id?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type UserWhereLookup = {
+  id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type UserWhereUnique = {

--- a/tests/generated/models.json
+++ b/tests/generated/models.json
@@ -83,9 +83,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true
       },
       {
@@ -222,9 +219,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true
       },
       {
@@ -328,9 +322,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true
       },
       {
@@ -437,9 +428,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true,
         "inherited": true
       },
@@ -563,9 +551,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true,
         "inherited": true
       },
@@ -682,9 +667,6 @@
         "type": "Boolean",
         "nonNull": true,
         "defaultValue": false,
-        "filterable": {
-          "default": false
-        },
         "generated": true,
         "inherited": true
       },

--- a/tests/generated/permissions.ts
+++ b/tests/generated/permissions.ts
@@ -12,7 +12,7 @@ export type PermissionsBlock = true | {
 export type UserWhere = {
 }
 export type UserPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -39,10 +39,9 @@ export type UserPermissions = {
   }
 }
 export type AnotherObjectWhere = {
-  deleted?: boolean | boolean[],
 }
 export type AnotherObjectPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -57,14 +56,13 @@ export type AnotherObjectPermissions = {
   }
 }
 export type SomeObjectWhere = {
-  field?: string | string[],
+  field?: string | readonly string[],
   another?: AnotherObjectWhere,
-  float?: number | number[],
-  xyz?: number | number[],
-  deleted?: boolean | boolean[],
+  float?: number | readonly number[],
+  xyz?: number | readonly number[],
 }
 export type SomeObjectPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -79,10 +77,9 @@ export type SomeObjectPermissions = {
   }
 }
 export type ReactionWhere = {
-  deleted?: boolean | boolean[],
 }
 export type ReactionPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -101,10 +98,9 @@ export type ReactionPermissions = {
   }
 }
 export type ReviewWhere = {
-  deleted?: boolean | boolean[],
 }
 export type ReviewPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -123,10 +119,9 @@ export type ReviewPermissions = {
   }
 }
 export type QuestionWhere = {
-  deleted?: boolean | boolean[],
 }
 export type QuestionPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,
@@ -145,10 +140,9 @@ export type QuestionPermissions = {
   }
 }
 export type AnswerWhere = {
-  deleted?: boolean | boolean[],
 }
 export type AnswerPermissions = {
-  READ?: true,
+  READ?: boolean,
   CREATE?: true,
   UPDATE?: true,
   DELETE?: true,

--- a/tests/generated/schema.graphql
+++ b/tests/generated/schema.graphql
@@ -7,8 +7,8 @@ type AnotherObject {
   deletedBy: User
   deleteRootType: String
   deleteRootId: ID
-  self(where: AnotherObjectWhere, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): AnotherObject
-  manyObjects(where: SomeObjectWhere, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
+  self(where: AnotherObjectWhere, deleted: Boolean = false, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): AnotherObject
+  manyObjects(where: SomeObjectWhere, deleted: Boolean = false, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
 }
 
 input AnotherObjectOrderBy {
@@ -18,7 +18,6 @@ input AnotherObjectOrderBy {
 
 input AnotherObjectSubWhere {
   id: [ID!]
-  deleted: [Boolean!]
   manyObjects_SOME: SomeObjectWhere
   manyObjects_NONE: SomeObjectWhere
   NOT: AnotherObjectSubWhere
@@ -28,12 +27,15 @@ input AnotherObjectSubWhere {
 
 input AnotherObjectWhere {
   id: [ID!]
-  deleted: [Boolean!]
   manyObjects_SOME: SomeObjectWhere
   manyObjects_NONE: SomeObjectWhere
   NOT: AnotherObjectSubWhere
   AND: [AnotherObjectSubWhere!]
   OR: [AnotherObjectSubWhere!]
+}
+
+input AnotherObjectWhereLookup {
+  id: ID
 }
 
 input AnotherObjectWhereUnique {
@@ -54,10 +56,10 @@ type Answer implements Reaction {
   deletedBy: User
   deleteRootType: String
   deleteRootId: ID
-  childReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  childReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  childQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  childAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  childReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  childReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  childQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  childAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
 }
 
 input AnswerOrderBy {
@@ -68,7 +70,6 @@ input AnswerOrderBy {
 
 input AnswerSubWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: AnswerSubWhere
   AND: [AnswerSubWhere!]
   OR: [AnswerSubWhere!]
@@ -76,10 +77,13 @@ input AnswerSubWhere {
 
 input AnswerWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: AnswerSubWhere
   AND: [AnswerSubWhere!]
   OR: [AnswerSubWhere!]
+}
+
+input AnswerWhereLookup {
+  id: ID
 }
 
 input AnswerWhereUnique {
@@ -144,17 +148,17 @@ enum Order {
 
 type Query {
   me: User
-  someObject(where: SomeObjectWhereUnique!): SomeObject!
-  reaction(where: ReactionWhereUnique!): Reaction!
-  review(where: ReviewWhereUnique!): Review!
-  question(where: QuestionWhereUnique!): Question!
-  answer(where: AnswerWhereUnique!): Answer!
-  anotherObjects(where: AnotherObjectWhere, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): [AnotherObject!]!
-  manyObjects(where: SomeObjectWhere, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
-  reactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  reviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  questions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  answers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  someObject(where: SomeObjectWhereLookup!, deleted: Boolean = false): SomeObject!
+  reaction(where: ReactionWhereLookup!, deleted: Boolean = false): Reaction!
+  review(where: ReviewWhereLookup!, deleted: Boolean = false): Review!
+  question(where: QuestionWhereLookup!, deleted: Boolean = false): Question!
+  answer(where: AnswerWhereLookup!, deleted: Boolean = false): Answer!
+  anotherObjects(where: AnotherObjectWhere, deleted: Boolean = false, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): [AnotherObject!]!
+  manyObjects(where: SomeObjectWhere, deleted: Boolean = false, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
+  reactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  reviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  questions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  answers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
   birds: [Bird!]!
 }
 
@@ -172,10 +176,10 @@ type Question implements Reaction {
   deletedBy: User
   deleteRootType: String
   deleteRootId: ID
-  childReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  childReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  childQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  childAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  childReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  childReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  childQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  childAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
 }
 
 input QuestionOrderBy {
@@ -186,7 +190,6 @@ input QuestionOrderBy {
 
 input QuestionSubWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: QuestionSubWhere
   AND: [QuestionSubWhere!]
   OR: [QuestionSubWhere!]
@@ -194,10 +197,13 @@ input QuestionSubWhere {
 
 input QuestionWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: QuestionSubWhere
   AND: [QuestionSubWhere!]
   OR: [QuestionSubWhere!]
+}
+
+input QuestionWhereLookup {
+  id: ID
 }
 
 input QuestionWhereUnique {
@@ -218,10 +224,10 @@ interface Reaction {
   deletedBy: User
   deleteRootType: String
   deleteRootId: ID
-  childReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  childReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  childQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  childAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  childReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  childReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  childQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  childAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
 }
 
 input ReactionOrderBy {
@@ -232,7 +238,6 @@ input ReactionOrderBy {
 
 input ReactionSubWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: ReactionSubWhere
   AND: [ReactionSubWhere!]
   OR: [ReactionSubWhere!]
@@ -246,10 +251,13 @@ enum ReactionType {
 
 input ReactionWhere {
   id: [ID!]
-  deleted: [Boolean!]
   NOT: ReactionSubWhere
   AND: [ReactionSubWhere!]
   OR: [ReactionSubWhere!]
+}
+
+input ReactionWhereLookup {
+  id: ID
 }
 
 input ReactionWhereUnique {
@@ -271,10 +279,10 @@ type Review implements Reaction {
   deleteRootType: String
   deleteRootId: ID
   rating: Float
-  childReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  childReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  childQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  childAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  childReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  childReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  childQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  childAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
 }
 
 input ReviewOrderBy {
@@ -285,7 +293,6 @@ input ReviewOrderBy {
 
 input ReviewSubWhere {
   id: [ID!]
-  deleted: [Boolean!]
   rating_GT: Float
   rating_GTE: Float
   rating_LT: Float
@@ -297,7 +304,6 @@ input ReviewSubWhere {
 
 input ReviewWhere {
   id: [ID!]
-  deleted: [Boolean!]
   rating_GT: Float
   rating_GTE: Float
   rating_LT: Float
@@ -305,6 +311,10 @@ input ReviewWhere {
   NOT: ReviewSubWhere
   AND: [ReviewSubWhere!]
   OR: [ReviewSubWhere!]
+}
+
+input ReviewWhereLookup {
+  id: ID
 }
 
 input ReviewWhereUnique {
@@ -353,7 +363,6 @@ input SomeObjectSubWhere {
   field: [String!]
   float: [Float!]
   xyz: [Int!]
-  deleted: [Boolean!]
   another: AnotherObjectWhere
   NOT: SomeObjectSubWhere
   AND: [SomeObjectSubWhere!]
@@ -365,11 +374,14 @@ input SomeObjectWhere {
   field: [String!]
   float: [Float!]
   xyz: [Int!]
-  deleted: [Boolean!]
   another: AnotherObjectWhere
   NOT: SomeObjectSubWhere
   AND: [SomeObjectSubWhere!]
   OR: [SomeObjectSubWhere!]
+}
+
+input SomeObjectWhereLookup {
+  id: ID
 }
 
 input SomeObjectWhereUnique {
@@ -407,22 +419,22 @@ type User {
   id: ID!
   username: String
   role: Role!
-  deletedAnotherObjects(where: AnotherObjectWhere, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): [AnotherObject!]!
-  createdManyObjects(where: SomeObjectWhere, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
-  updatedManyObjects(where: SomeObjectWhere, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
-  deletedManyObjects(where: SomeObjectWhere, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
-  createdReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  updatedReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  deletedReactions(where: ReactionWhere, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
-  createdReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  updatedReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  deletedReviews(where: ReviewWhere, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
-  createdQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  updatedQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  deletedQuestions(where: QuestionWhere, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
-  createdAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
-  updatedAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
-  deletedAnswers(where: AnswerWhere, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  deletedAnotherObjects(where: AnotherObjectWhere, deleted: Boolean = false, orderBy: [AnotherObjectOrderBy!], limit: Int, offset: Int): [AnotherObject!]!
+  createdManyObjects(where: SomeObjectWhere, deleted: Boolean = false, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
+  updatedManyObjects(where: SomeObjectWhere, deleted: Boolean = false, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
+  deletedManyObjects(where: SomeObjectWhere, deleted: Boolean = false, search: String, orderBy: [SomeObjectOrderBy!], limit: Int, offset: Int): [SomeObject!]!
+  createdReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  updatedReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  deletedReactions(where: ReactionWhere, deleted: Boolean = false, orderBy: [ReactionOrderBy!], limit: Int, offset: Int): [Reaction!]!
+  createdReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  updatedReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  deletedReviews(where: ReviewWhere, deleted: Boolean = false, orderBy: [ReviewOrderBy!], limit: Int, offset: Int): [Review!]!
+  createdQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  updatedQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  deletedQuestions(where: QuestionWhere, deleted: Boolean = false, orderBy: [QuestionOrderBy!], limit: Int, offset: Int): [Question!]!
+  createdAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  updatedAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
+  deletedAnswers(where: AnswerWhere, deleted: Boolean = false, orderBy: [AnswerOrderBy!], limit: Int, offset: Int): [Answer!]!
 }
 
 input UserSubWhere {
@@ -437,6 +449,10 @@ input UserWhere {
   NOT: UserSubWhere
   AND: [UserSubWhere!]
   OR: [UserSubWhere!]
+}
+
+input UserWhereLookup {
+  id: ID
 }
 
 input UserWhereUnique {

--- a/tests/unit/includes-deleted-rows.spec.ts
+++ b/tests/unit/includes-deleted-rows.spec.ts
@@ -1,0 +1,13 @@
+import { includesDeletedRows } from '../../src/resolvers/filters';
+
+describe('includesDeletedRows', () => {
+  it('is false for the default non-deleted query', () => {
+    expect(includesDeletedRows(undefined)).toBe(false);
+    expect(includesDeletedRows(false)).toBe(false);
+  });
+
+  it('is true when the query opts into deleted rows', () => {
+    expect(includesDeletedRows(true)).toBe(true);
+    expect(includesDeletedRows(null)).toBe(true);
+  });
+});


### PR DESCRIPTION
Soft-deleted rows are no longer part of Where inputs. List, aggregate, singular, and reverse-relation queries on deletable entities take `deleted: Boolean = false` instead. Skip the cascade-deletion OR in permission EXISTS when the query does not include deleted rows.