### PR TITLE
fix(ZWEI-3796): pass includesDeletedRows for RESTORE permission check

### DIFF
--- a/src/permissions/check.ts
+++ b/src/permissions/check.ts
@@ -108,7 +108,7 @@ export const getEntityToMutate = async (
     throw new NotFoundError(`${model.name} to ${action.toLowerCase()} not found`);
   }
 
-  applyPermissions(ctx, model.name, model.name, query, action);
+  applyPermissions(ctx, model.name, model.name, query, action, undefined, action === 'RESTORE');
   entity = await query;
   if (!entity) {
     throw new PermissionError(getRole(ctx), action, `this ${model.name}`, 'no available permissions applied');


### PR DESCRIPTION
getEntityToMutate must allow permission paths to match already-deleted rows when restoring, same as list queries with deleted: true.