### PR TITLE
feat(permissions): skip nested-deleted default on schema-mandated cas…

### DIFF
--- a/src/resolvers/filters.ts
+++ b/src/resolvers/filters.ts
@@ -338,7 +338,19 @@ const applyWhere = (node: FilterNode, where: Where | undefined, ops: QueryBuilde
         tableAlias,
       };
       addJoin(joins, node.tableAlias, subNode.model.name, subNode.tableAlias, relation.field.foreignKey, 'id');
-      applyNestedDeletedDefault(subNode, ops);
+      // Same rationale as `collectMandatoryFilterAliases`: a
+      // `filterable: { nonNull: true }` relation is a schema contract
+      // that EVERY client must traverse, and the cascade contents are
+      // forced too. Applying `deleted = false` on that joined table
+      // would silently drop rows the client had no opt-out from
+      // filtering through — e.g. a deleted goal whose relation is
+      // also deleted disappears from `/admin/goals?deleted=true`,
+      // even though the user explicitly asked for deleted ones. Same
+      // alignment: the schema-mandated path doesn't get extra hidden
+      // restrictions.
+      if (!isMandatoryFilterField(relation.field.filterable) || !isMinimalFilterShape(targetModel, value as Where)) {
+        applyNestedDeletedDefault(subNode, ops);
+      }
       applyWhere(subNode, value as Where, ops, joins);
       continue;
     }


### PR DESCRIPTION
…cade

Aligned with the existing mandatory-filter rule: a `filterable: { nonNull: true }` relation is a schema contract that EVERY client must traverse, and when the contents at the join are themselves minimal (only nonNull-filterable fields, recursively), the runtime should not enforce an additional `deleted = false` filter on the joined table. The client had no opt-out from the filter — the schema forced it — and graphql-magic silently dropping rows that fail that hidden constraint is the same kind of "schema-mandated path imposes a hidden restriction" the permission side already rejects.

Concrete symptom (this MR's `/admin/goals?deleted=true` listing for an EXPERT after the test marks a Relation as deleted, exposed by expert.spec.ts:1617 "delete relation"):

  Goal a836... has status=ACTIVE, deleted=true, relation=Foobar
  Foobar has status=ACTIVE, deleted=true

  query: goals(where: { status:[ACTIVE,INACTIVE], relation:{ status:[ACTIVE,INACTIVE] } }, deleted: true)

Without this change `applyNestedDeletedDefault` adds `G__W__r.deleted = false`, and the row disappears even though the client asked for deleted goals and had no way to express "include relations regardless of deleted state" — `RelationWhere` has no `deleted` field. With this change the joined table is unrestricted on `deleted` for the schema-mandated path, the row surfaces, and the restore flow works.

Optional / opt-in filters (plain `filterable: true` relation, any non-mandatory leaf in the sub-where, `_<OP>`, `_SOME` / `_NONE`) still get the default applied — those are explicit client choices and continue to be permission/deleted-gated as before.