### PR TITLE
feat!: stable constraint/trigger names without positional suffix

### DIFF
--- a/docs/docs/5-migrations.md
+++ b/docs/docs/5-migrations.md
@@ -35,7 +35,15 @@ If an entity defines [constraints](./2-models.md#constraints), the migration gen
 - **New tables**: add each constraint in the `up` migration.
 - **Existing tables**: add new constraints, and for existing constraints, if the definition changed, drop and re-add the constraint.
 
-Constraint names follow the pattern `{table}_{constraintName}_{kind}_{index}`.
+Constraint names follow the pattern `{table}_{constraintName}_{kind}`. The name is independent of the
+constraint's position in the model's `constraints` list, so reordering or inserting constraints never
+renames the others. Because there is no positional suffix, the `{constraintName}` must be unique per table
+and kind; the generator throws if two constraints on the same table would produce the same name.
+
+> **Upgrading from the positional scheme:** earlier versions suffixed the name with the constraint's index
+> (`{table}_{constraintName}_{kind}_{index}`). To migrate an existing database to the suffix-free names in
+> one step, run `npx gqm generate-constraint-rename-migration` and apply the generated migration; on an
+> already-migrated database it produces an empty migration.
 
 **Check constraints** (`kind: 'check'`): Expression changes trigger a migration.
 

--- a/src/bin/gqm/gqm.ts
+++ b/src/bin/gqm/gqm.ts
@@ -121,6 +121,28 @@ const commands: Record<string, Command> = {
       }
     },
   },
+  'generate-constraint-rename-migration': {
+    description: 'Generate a one-off migration renaming constraints/triggers/indexes to the stable (suffix-free) names',
+    usage: 'gqm generate-constraint-rename-migration [<name>] [<date>]',
+    run: async (positionals) => {
+      const [providedName, date] = positionals;
+      const name = providedName || 'rename-constraints-to-stable-names';
+
+      const knexfile = await parseKnexfile();
+      const db = knex(knexfile);
+
+      try {
+        const models = await parseModels();
+        const functionsPath = await getSetting('functionsPath');
+        const parsedFunctions = parseFunctionsFile(functionsPath);
+        const migration = await new MigrationGenerator(db, models, parsedFunctions).generateConstraintRenameMigration();
+
+        writeToFile(`migrations/${date || getMigrationDate()}_${name}.ts`, migration);
+      } finally {
+        await db.destroy();
+      }
+    },
+  },
   'check-needs-migration': {
     description: 'Check if a migration is needed',
     usage: 'gqm check-needs-migration',

--- a/src/migrations/generate.ts
+++ b/src/migrations/generate.ts
@@ -301,40 +301,40 @@ export class MigrationGenerator {
           });
 
           if (model.constraints?.length) {
-            for (let i = 0; i < model.constraints.length; i++) {
-              const entry = model.constraints[i];
+            this.validateConstraintNames(model);
+            for (const entry of model.constraints) {
               if (entry.kind === 'check') {
                 validateCheckConstraint(model, entry);
                 const table = model.name;
-                const constraintName = this.getConstraintName(model, entry, i);
+                const constraintName = this.getConstraintName(model, entry);
                 up.push(() => {
                   this.addCheckConstraint(table, constraintName, entry.expression, entry.deferrable, entry.notValid);
                 });
               } else if (entry.kind === 'exclude') {
                 validateExcludeConstraint(model, entry);
                 const table = model.name;
-                const constraintName = this.getConstraintName(model, entry, i);
+                const constraintName = this.getConstraintName(model, entry);
                 up.push(() => {
                   this.addExcludeConstraint(table, constraintName, entry);
                 });
               } else if (entry.kind === 'constraint_trigger') {
                 this.validateConstraintTrigger(model, entry);
                 const table = model.name;
-                const constraintName = this.getConstraintName(model, entry, i);
+                const constraintName = this.getConstraintName(model, entry);
                 up.push(() => {
                   this.addConstraintTrigger(table, constraintName, entry);
                 });
               } else if (entry.kind === 'trigger') {
                 this.validateTriggerFunction(model, entry);
                 const table = model.name;
-                const triggerName = this.getConstraintName(model, entry, i);
+                const triggerName = this.getConstraintName(model, entry);
                 up.push(() => {
                   this.addTrigger(table, triggerName, entry);
                 });
               } else if (entry.kind === 'unique') {
                 validateUniqueConstraint(model, entry);
                 const table = model.name;
-                const constraintName = this.getConstraintName(model, entry, i);
+                const constraintName = this.getConstraintName(model, entry);
                 up.push(() => {
                   this.addUniqueIndex(table, constraintName, entry);
                 });
@@ -392,16 +392,16 @@ export class MigrationGenerator {
           this.updateFields(model, existingFields, up, down);
 
           if (model.constraints?.length) {
+            this.validateConstraintNames(model);
             const existingExcludeMap = this.existingExcludeConstraints[model.name];
             const existingTriggerMap = this.existingConstraintTriggers[model.name];
             const existingPlainTriggerMap = this.existingTriggers[model.name];
-            for (let i = 0; i < model.constraints.length; i++) {
-              const entry = model.constraints[i];
+            for (const entry of model.constraints) {
               const table = model.name;
-              const constraintName = this.getConstraintName(model, entry, i);
+              const constraintName = this.getConstraintName(model, entry);
               if (entry.kind === 'check') {
                 validateCheckConstraint(model, entry);
-                const existingConstraint = this.findExistingConstraint(table, entry, constraintName);
+                const existingConstraint = this.findExistingConstraint(table, constraintName);
                 if (!existingConstraint) {
                   up.push(() => {
                     this.addCheckConstraint(table, constraintName, entry.expression, entry.deferrable, entry.notValid);
@@ -675,6 +675,138 @@ export class MigrationGenerator {
     }
     this.migration('up', up);
     this.migration('down', down.reverse());
+
+    return writer.toString();
+  }
+
+  /**
+   * Generate a one-off migration that renames every managed constraint/trigger/index from the legacy
+   * positional scheme (`{table}_{name}_{kind}_{index}`) to the current stable scheme (`{table}_{name}_{kind}`).
+   *
+   * Run this once when upgrading across the naming change: it inspects the live database, matches each
+   * model constraint to its legacy-named object by the `{stableName}_{index}` pattern, and emits the
+   * reversible RENAME statements. On an already-migrated database nothing matches and it produces an
+   * empty migration — the signal that the rename is complete.
+   */
+  public async generateConstraintRenameMigration(): Promise<string> {
+    const { writer, schema, models } = this;
+
+    const loadNames = async (sql: string): Promise<Record<string, Set<string>>> => {
+      const result = await schema.knex.raw(sql);
+      const rows: { table_name: string; object_name: string }[] =
+        'rows' in result && Array.isArray((result as { rows: unknown }).rows)
+          ? (result as { rows: { table_name: string; object_name: string }[] }).rows
+          : [];
+      const map: Record<string, Set<string>> = {};
+      for (const row of rows) {
+        const table = row.table_name.split('.').pop()?.replace(/^"|"$/g, '') ?? row.table_name;
+        (map[table] ??= new Set()).add(row.object_name);
+      }
+
+      return map;
+    };
+
+    // Names as gqm introspects them: constraints + constraint-triggers by pg_constraint.conname, plain
+    // triggers by pg_trigger.tgname, unique (partial) indexes by the index relation name.
+    const checkConstraints = await loadNames(
+      `SELECT c.conrelid::regclass::text AS table_name, c.conname AS object_name FROM pg_constraint c JOIN pg_namespace n ON c.connamespace = n.oid WHERE n.nspname = 'public' AND c.contype = 'c'`,
+    );
+    const excludeConstraints = await loadNames(
+      `SELECT c.conrelid::regclass::text AS table_name, c.conname AS object_name FROM pg_constraint c JOIN pg_namespace n ON c.connamespace = n.oid WHERE n.nspname = 'public' AND c.contype = 'x'`,
+    );
+    const constraintTriggers = await loadNames(
+      `SELECT c.conrelid::regclass::text AS table_name, c.conname AS object_name FROM pg_constraint c JOIN pg_namespace n ON c.connamespace = n.oid WHERE n.nspname = 'public' AND c.contype = 't'`,
+    );
+    const plainTriggers = await loadNames(
+      `SELECT c.relname AS table_name, t.tgname AS object_name FROM pg_trigger t JOIN pg_class c ON t.tgrelid = c.oid JOIN pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND NOT t.tgisinternal AND t.tgconstraint = 0`,
+    );
+    const uniqueIndexes = await loadNames(
+      `SELECT t.relname AS table_name, i.relname AS object_name FROM pg_index ix JOIN pg_class i ON i.oid = ix.indexrelid JOIN pg_class t ON t.oid = ix.indrelid JOIN pg_namespace n ON n.oid = t.relnamespace WHERE n.nspname = 'public' AND ix.indisunique AND NOT ix.indisprimary AND NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conindid = ix.indexrelid)`,
+    );
+
+    // Find the legacy-named object (`{stableName}_{index}`) for a stable name; undefined if it is absent
+    // or already renamed to the stable name.
+    const findLegacyName = (existing: Set<string> | undefined, stableName: string): string | undefined => {
+      if (!existing || existing.has(stableName)) {
+        return undefined;
+      }
+      const legacyPattern = new RegExp(`^${stableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}_\\d+$`);
+      for (const name of existing) {
+        if (legacyPattern.test(name)) {
+          return name;
+        }
+      }
+
+      return undefined;
+    };
+
+    const renameConstraint = (table: string, from: string, to: string) =>
+      `await knex.raw('ALTER TABLE "${table}" RENAME CONSTRAINT "${from}" TO "${to}"');`;
+    const renameTrigger = (table: string, from: string, to: string) =>
+      `await knex.raw('ALTER TRIGGER "${from}" ON "${table}" RENAME TO "${to}"');`;
+    const renameIndex = (from: string, to: string) => `await knex.raw('ALTER INDEX "${from}" RENAME TO "${to}"');`;
+
+    const up: string[] = [];
+    const down: string[] = [];
+
+    for (const model of models.entities) {
+      if (!model.constraints?.length) {
+        continue;
+      }
+      this.validateConstraintNames(model);
+      const table = model.name;
+      for (const entry of model.constraints) {
+        const stableName = this.getConstraintName(model, entry);
+        if (entry.kind === 'check' || entry.kind === 'exclude') {
+          const legacy = findLegacyName(
+            entry.kind === 'check' ? checkConstraints[table] : excludeConstraints[table],
+            stableName,
+          );
+          if (!legacy) {
+            continue;
+          }
+          up.push(renameConstraint(table, legacy, stableName));
+          down.push(renameConstraint(table, stableName, legacy));
+        } else if (entry.kind === 'constraint_trigger') {
+          const legacy = findLegacyName(constraintTriggers[table], stableName);
+          if (!legacy) {
+            continue;
+          }
+          // A constraint trigger owns both a pg_constraint (conname, what gqm matches) and a pg_trigger
+          // (tgname); RENAME CONSTRAINT and ALTER TRIGGER each touch only one, so rename both to stay in sync.
+          up.push(renameConstraint(table, legacy, stableName), renameTrigger(table, legacy, stableName));
+          down.push(renameConstraint(table, stableName, legacy), renameTrigger(table, stableName, legacy));
+        } else if (entry.kind === 'trigger') {
+          const legacy = findLegacyName(plainTriggers[table], stableName);
+          if (!legacy) {
+            continue;
+          }
+          up.push(renameTrigger(table, legacy, stableName));
+          down.push(renameTrigger(table, stableName, legacy));
+        } else if (entry.kind === 'unique') {
+          const legacy = findLegacyName(uniqueIndexes[table], stableName);
+          if (!legacy) {
+            continue;
+          }
+          up.push(renameIndex(legacy, stableName));
+          down.push(renameIndex(stableName, legacy));
+        }
+      }
+    }
+
+    if (up.length) {
+      this.needsMigration = true;
+    }
+
+    writer.writeLine(`import { Knex } from 'knex';`).blankLine();
+    this.migration(
+      'up',
+      up.map((line) => () => writer.writeLine(line)),
+    );
+    this.migration(
+      'down',
+      down.reverse().map((line) => () => writer.writeLine(line)),
+    );
 
     return writer.toString();
   }
@@ -992,15 +1124,38 @@ export class MigrationGenerator {
 
   private static readonly POSTGRES_MAX_IDENTIFIER_LENGTH = 63;
 
-  private getConstraintName(model: EntityModel, entry: { kind: string; name: string }, index: number): string {
-    const name = `${model.name}_${entry.name}_${entry.kind}_${index}`;
+  // Constraint/trigger object names are `{table}_{constraintName}_{kind}` — stable and independent of the
+  // constraint's position in the model's `constraints` array. Per-table uniqueness of these names is
+  // enforced by `validateConstraintNames` (called once per model), so no positional suffix is needed.
+  private getConstraintName(model: EntityModel, entry: { kind: string; name: string }): string {
+    const name = `${model.name}_${entry.name}_${entry.kind}`;
     if (name.length > MigrationGenerator.POSTGRES_MAX_IDENTIFIER_LENGTH) {
       throw new Error(
-        `Generated constraint name "${name}" (${name.length} characters) exceeds PostgreSQL's maximum identifier length of ${MigrationGenerator.POSTGRES_MAX_IDENTIFIER_LENGTH} characters. Shorten the constraint name "${entry.name}" on model "${model.name}" (pattern: {table}_{constraintName}_{kind}_{index}).`,
+        `Generated constraint name "${name}" (${name.length} characters) exceeds PostgreSQL's maximum identifier length of ${MigrationGenerator.POSTGRES_MAX_IDENTIFIER_LENGTH} characters. Shorten the constraint name "${entry.name}" on model "${model.name}" (pattern: {table}_{constraintName}_{kind}).`,
       );
     }
 
     return name;
+  }
+
+  // A model's constraint names must be unique per table: with the positional suffix gone, two entries that
+  // share the same `{table}_{name}_{kind}` would collide on one Postgres object. Fail fast with a clear
+  // message pointing at the offending name so the model author renames one of them.
+  private validateConstraintNames(model: EntityModel): void {
+    if (!model.constraints?.length) {
+      return;
+    }
+
+    const seen = new Set<string>();
+    for (const entry of model.constraints) {
+      const name = this.getConstraintName(model, entry);
+      if (seen.has(name)) {
+        throw new Error(
+          `Duplicate constraint name "${name}" on model "${model.name}": two entries in its \`constraints\` produce the same object name. Give the constraint "${entry.name}" (kind "${entry.kind}") a distinct name.`,
+        );
+      }
+      seen.add(name);
+    }
   }
 
   private static readonly SQL_KEYWORDS = new Set([
@@ -1206,7 +1361,6 @@ export class MigrationGenerator {
 
   private findExistingConstraint(
     table: string,
-    entry: { kind: 'check'; name: string; expression: string },
     preferredConstraintName: string,
   ): { constraintName: string; expression: string; notValid: boolean } | null {
     const existingMap = this.existingCheckConstraints[table];
@@ -1214,6 +1368,9 @@ export class MigrationGenerator {
       return null;
     }
 
+    // Constraint names are now stable (`{table}_{name}_{kind}`, no positional suffix), so an existing
+    // constraint is matched by its exact name. The former prefix+expression fallback existed only to
+    // re-associate a check whose positional suffix had shifted; that can no longer happen.
     const preferred = existingMap.get(preferredConstraintName);
     if (preferred !== undefined) {
       return {
@@ -1221,20 +1378,6 @@ export class MigrationGenerator {
         expression: preferred.expression,
         notValid: preferred.notValid,
       };
-    }
-
-    const normalizedNewExpression = this.normalizeCheckExpression(entry.expression);
-    const constraintPrefix = `${table}_${entry.name}_${entry.kind}_`;
-
-    for (const [constraintName, { expression, notValid }] of existingMap.entries()) {
-      if (!constraintName.startsWith(constraintPrefix)) {
-        continue;
-      }
-      if (this.normalizeCheckExpression(expression) !== normalizedNewExpression) {
-        continue;
-      }
-
-      return { constraintName, expression, notValid };
     }
 
     return null;

--- a/tests/unit/migration-constraints.spec.ts
+++ b/tests/unit/migration-constraints.spec.ts
@@ -145,7 +145,7 @@ describe('MigrationGenerator check constraints', () => {
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_score_non_negative_check_0',
+          constraint_name: 'Product_score_non_negative_check',
           constraint_def: 'CHECK ( (( "score"   >=   0 )) )',
           convalidated: true,
         },
@@ -184,7 +184,7 @@ describe('MigrationGenerator check constraints', () => {
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_period_start_before_end_check_0',
+          constraint_name: 'Product_period_start_before_end_check',
           constraint_def: 'CHECK (((deleted = true) OR ("endDate" IS NULL) OR ("startDate" <= "endDate")))',
           convalidated: true,
         },
@@ -197,7 +197,7 @@ describe('MigrationGenerator check constraints', () => {
     expect(generator.needsMigration).toBe(false);
   });
 
-  it('does not detect changes if only generated constraint index changed but expression is identical', async () => {
+  it('does not detect changes when the stable constraint names and expressions match', async () => {
     const models = createProductModels([
       { kind: 'check', name: 'first', expression: '"score" >= 0' },
       { kind: 'check', name: 'second', expression: '"score" <= 100' },
@@ -206,13 +206,13 @@ describe('MigrationGenerator check constraints', () => {
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_first_check_1',
+          constraint_name: 'Product_first_check',
           constraint_def: 'CHECK ((("score" >= 0)))',
           convalidated: true,
         },
         {
           table_name: 'Product',
-          constraint_name: 'Product_second_check_0',
+          constraint_name: 'Product_second_check',
           constraint_def: 'CHECK ((("score" <= 100)))',
           convalidated: true,
         },
@@ -225,13 +225,34 @@ describe('MigrationGenerator check constraints', () => {
     expect(generator.needsMigration).toBe(false);
   });
 
+  it('detects a needed migration when a constraint still carries the legacy positional suffix', async () => {
+    // Constraint names no longer carry a positional suffix, so a legacy `_{index}`-named constraint is
+    // NOT matched to its model entry — it must be renamed (see generate-constraint-rename-migration).
+    const models = createProductModels([{ kind: 'check', name: 'first', expression: '"score" >= 0' }]);
+    const generator = createGenerator(
+      [
+        {
+          table_name: 'Product',
+          constraint_name: 'Product_first_check_0',
+          constraint_def: 'CHECK ((("score" >= 0)))',
+          convalidated: true,
+        },
+      ],
+      models,
+    );
+
+    await generator.generate();
+
+    expect(generator.needsMigration).toBe(true);
+  });
+
   it('still detects actual expression changes', async () => {
     const models = createProductModels([{ kind: 'check', name: 'score_non_negative', expression: '"score" >= 0' }]);
     const generator = createGenerator(
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_score_non_negative_check_0',
+          constraint_name: 'Product_score_non_negative_check',
           constraint_def: 'CHECK (("score" > 0))',
           convalidated: true,
         },
@@ -242,8 +263,8 @@ describe('MigrationGenerator check constraints', () => {
     const migration = await generator.generate();
 
     expect(generator.needsMigration).toBe(true);
-    expect(migration).toContain('DROP CONSTRAINT "Product_score_non_negative_check_0"');
-    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check_0" CHECK ("score" >= 0)');
+    expect(migration).toContain('DROP CONSTRAINT "Product_score_non_negative_check"');
+    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check" CHECK ("score" >= 0)');
   });
 
   it('appends NOT VALID when notValid is true', async () => {
@@ -254,7 +275,7 @@ describe('MigrationGenerator check constraints', () => {
 
     const migration = await generator.generate();
 
-    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check_0" CHECK ("score" >= 0) NOT VALID');
+    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check" CHECK ("score" >= 0) NOT VALID');
   });
 
   it('detects when notValid has changed', async () => {
@@ -265,7 +286,7 @@ describe('MigrationGenerator check constraints', () => {
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_score_non_negative_check_0',
+          constraint_name: 'Product_score_non_negative_check',
           constraint_def: 'CHECK (("score" >= 0))',
           convalidated: true,
         },
@@ -276,8 +297,8 @@ describe('MigrationGenerator check constraints', () => {
     const migration = await generator.generate();
 
     expect(generator.needsMigration).toBe(true);
-    expect(migration).toContain('DROP CONSTRAINT "Product_score_non_negative_check_0"');
-    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check_0" CHECK ("score" >= 0) NOT VALID');
+    expect(migration).toContain('DROP CONSTRAINT "Product_score_non_negative_check"');
+    expect(migration).toContain('ADD CONSTRAINT "Product_score_non_negative_check" CHECK ("score" >= 0) NOT VALID');
   });
 
   it('warns and treats constraint as changed when canonicalization fails', async () => {
@@ -290,7 +311,7 @@ describe('MigrationGenerator check constraints', () => {
       [
         {
           table_name: 'Product',
-          constraint_name: 'Product_score_non_negative_check_0',
+          constraint_name: 'Product_score_non_negative_check',
           constraint_def: 'CHECK (("score" >= 0))',
           convalidated: true,
         },
@@ -358,7 +379,22 @@ describe('MigrationGenerator constraint name length', () => {
     const generator = createGenerator([], models);
 
     await expect(generator.generate()).rejects.toThrow(
-      /Generated constraint name "Product_.*_check_0" \(6\d characters\) exceeds PostgreSQL's maximum identifier length of 63 characters/,
+      /Generated constraint name "Product_.*_check" \(6\d characters\) exceeds PostgreSQL's maximum identifier length of 63 characters/,
+    );
+  });
+});
+
+describe('MigrationGenerator duplicate constraint names', () => {
+  it('throws when two constraints on the same table produce the same name', async () => {
+    // Without a positional suffix, two entries with the same name + kind collide on one Postgres object.
+    const models = createProductModels([
+      { kind: 'check', name: 'score_bound', expression: '"score" >= 0' },
+      { kind: 'check', name: 'score_bound', expression: '"score" <= 100' },
+    ]);
+    const generator = createGenerator([], models);
+
+    await expect(generator.generate()).rejects.toThrow(
+      /Duplicate constraint name "Product_score_bound_check" on model "Product"/,
     );
   });
 });
@@ -532,7 +568,7 @@ describe('MigrationGenerator trigger (regular, non-constraint)', () => {
 
   // pg_get_triggerdef output for the trigger defined by createTriggerModels (default options).
   const dbTriggerDef =
-    'CREATE TRIGGER "Customer_mirror_status_trigger_0" AFTER INSERT OR UPDATE ON public."Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()';
+    'CREATE TRIGGER "Customer_mirror_status_trigger" AFTER INSERT OR UPDATE ON public."Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()';
 
   it('creates a CREATE TRIGGER when none exists (existing table)', async () => {
     const generator = createTriggerGenerator(createTriggerModels(), [], true);
@@ -540,18 +576,18 @@ describe('MigrationGenerator trigger (regular, non-constraint)', () => {
 
     expect(generator.needsMigration).toBe(true);
     expect(migration).toContain(
-      'CREATE TRIGGER "Customer_mirror_status_trigger_0" AFTER INSERT OR UPDATE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
+      'CREATE TRIGGER "Customer_mirror_status_trigger" AFTER INSERT OR UPDATE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
     );
     expect(migration).not.toContain('CREATE CONSTRAINT TRIGGER');
     expect(migration).not.toContain('DEFERRABLE');
     // down drops it
-    expect(migration).toContain('DROP TRIGGER IF EXISTS "Customer_mirror_status_trigger_0" ON "Customer"');
+    expect(migration).toContain('DROP TRIGGER IF EXISTS "Customer_mirror_status_trigger" ON "Customer"');
   });
 
   it('does not detect changes when the trigger already matches (idempotent)', async () => {
     const generator = createTriggerGenerator(
       createTriggerModels(),
-      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger_0', trigger_def: dbTriggerDef }],
+      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger', trigger_def: dbTriggerDef }],
       true,
     );
 
@@ -563,7 +599,7 @@ describe('MigrationGenerator trigger (regular, non-constraint)', () => {
   it('is idempotent regardless of event ordering in the existing def', async () => {
     const generator = createTriggerGenerator(
       createTriggerModels({ events: ['UPDATE', 'INSERT'] }),
-      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger_0', trigger_def: dbTriggerDef }],
+      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger', trigger_def: dbTriggerDef }],
       true,
     );
 
@@ -576,16 +612,16 @@ describe('MigrationGenerator trigger (regular, non-constraint)', () => {
     const generator = createTriggerGenerator(
       // Model now also fires on DELETE -> differs from the stored def.
       createTriggerModels({ events: ['INSERT', 'UPDATE', 'DELETE'] }),
-      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger_0', trigger_def: dbTriggerDef }],
+      [{ table_name: 'Customer', trigger_name: 'Customer_mirror_status_trigger', trigger_def: dbTriggerDef }],
       true,
     );
 
     const migration = await generator.generate();
 
     expect(generator.needsMigration).toBe(true);
-    expect(migration).toContain('DROP TRIGGER IF EXISTS "Customer_mirror_status_trigger_0" ON "Customer"');
+    expect(migration).toContain('DROP TRIGGER IF EXISTS "Customer_mirror_status_trigger" ON "Customer"');
     expect(migration).toContain(
-      'CREATE TRIGGER "Customer_mirror_status_trigger_0" AFTER INSERT OR UPDATE OR DELETE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
+      'CREATE TRIGGER "Customer_mirror_status_trigger" AFTER INSERT OR UPDATE OR DELETE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
     );
   });
 
@@ -596,7 +632,7 @@ describe('MigrationGenerator trigger (regular, non-constraint)', () => {
 
     expect(generator.needsMigration).toBe(true);
     expect(migration).toContain(
-      'CREATE TRIGGER "Customer_mirror_status_trigger_0" AFTER INSERT OR UPDATE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
+      'CREATE TRIGGER "Customer_mirror_status_trigger" AFTER INSERT OR UPDATE ON "Customer" FOR EACH ROW EXECUTE FUNCTION mirror_user_status()',
     );
   });
 
@@ -665,9 +701,9 @@ describe('MigrationGenerator unique constraints', () => {
 
     expect(generator.needsMigration).toBe(true);
     expect(migration).toContain(
-      'CREATE UNIQUE INDEX "Product_start_end_unique_0" ON "Product" ("startDate", "endDate") WHERE "deleted" = false',
+      'CREATE UNIQUE INDEX "Product_start_end_unique" ON "Product" ("startDate", "endDate") WHERE "deleted" = false',
     );
-    expect(migration).toContain('DROP INDEX IF EXISTS "Product_start_end_unique_0"');
+    expect(migration).toContain('DROP INDEX IF EXISTS "Product_start_end_unique"');
   });
 
   it('emits a non-partial unique index when no where is given', async () => {
@@ -676,8 +712,8 @@ describe('MigrationGenerator unique constraints', () => {
 
     const migration = await generator.generate();
 
-    expect(migration).toContain('CREATE UNIQUE INDEX "Product_start_end_unique_0" ON "Product" ("startDate", "endDate")');
-    expect(migration).not.toContain('Product_start_end_unique_0" ON "Product" ("startDate", "endDate") WHERE');
+    expect(migration).toContain('CREATE UNIQUE INDEX "Product_start_end_unique" ON "Product" ("startDate", "endDate")');
+    expect(migration).not.toContain('Product_start_end_unique" ON "Product" ("startDate", "endDate") WHERE');
   });
 
   it('detects no change when the existing partial index matches (pg_get_indexdef shape)', async () => {
@@ -688,9 +724,9 @@ describe('MigrationGenerator unique constraints', () => {
       [
         {
           table_name: 'Product',
-          index_name: 'Product_start_end_unique_0',
+          index_name: 'Product_start_end_unique',
           index_def:
-            'CREATE UNIQUE INDEX "Product_start_end_unique_0" ON public."Product" USING btree ("startDate", "endDate") WHERE (deleted = false)',
+            'CREATE UNIQUE INDEX "Product_start_end_unique" ON public."Product" USING btree ("startDate", "endDate") WHERE (deleted = false)',
         },
       ],
       models,
@@ -709,9 +745,9 @@ describe('MigrationGenerator unique constraints', () => {
       [
         {
           table_name: 'Product',
-          index_name: 'Product_start_end_unique_0',
+          index_name: 'Product_start_end_unique',
           index_def:
-            'CREATE UNIQUE INDEX "Product_start_end_unique_0" ON public."Product" USING btree ("startDate") WHERE (deleted = false)',
+            'CREATE UNIQUE INDEX "Product_start_end_unique" ON public."Product" USING btree ("startDate") WHERE (deleted = false)',
         },
       ],
       models,
@@ -720,9 +756,9 @@ describe('MigrationGenerator unique constraints', () => {
     const migration = await generator.generate();
 
     expect(generator.needsMigration).toBe(true);
-    expect(migration).toContain('DROP INDEX IF EXISTS "Product_start_end_unique_0"');
+    expect(migration).toContain('DROP INDEX IF EXISTS "Product_start_end_unique"');
     expect(migration).toContain(
-      'CREATE UNIQUE INDEX "Product_start_end_unique_0" ON "Product" ("startDate", "endDate") WHERE "deleted" = false',
+      'CREATE UNIQUE INDEX "Product_start_end_unique" ON "Product" ("startDate", "endDate") WHERE "deleted" = false',
     );
   });
 
@@ -734,9 +770,9 @@ describe('MigrationGenerator unique constraints', () => {
       [
         {
           table_name: 'Product',
-          index_name: 'Product_start_end_unique_0',
+          index_name: 'Product_start_end_unique',
           index_def:
-            'CREATE UNIQUE INDEX "Product_start_end_unique_0" ON public."Product" USING btree ("startDate", "endDate")',
+            'CREATE UNIQUE INDEX "Product_start_end_unique" ON public."Product" USING btree ("startDate", "endDate")',
         },
       ],
       models,


### PR DESCRIPTION
Constraint and trigger objects are now named `{table}_{name}_{kind}` instead of `{table}_{name}_{kind}_{index}`. The name no longer depends on the constraint's position in the model's `constraints` array, so inserting or reordering a constraint never renames — and therefore never recreates — the others.

Because the positional suffix is gone, constraint names must be unique per table and kind; the generator now throws a clear error if two constraints on the same table would collide.

Adds `gqm generate-constraint-rename-migration`: a one-off command that renames every existing constraint/trigger/index from the legacy positional scheme to the stable names. On an already-migrated database it produces an empty migration.

BREAKING CHANGE: constraint/trigger/index names generated by graphql-magic no longer include the positional `_{index}` suffix. Databases created with an earlier version must be migrated once with `gqm generate-constraint-rename-migration` (then apply the result) so existing object names match the new scheme; otherwise `check-needs-migration` will report that a migration is needed.